### PR TITLE
Wire up main window actions and add launcher helper

### DIFF
--- a/AnSAM/GameLauncher.cs
+++ b/AnSAM/GameLauncher.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace AnSAM
+{
+    public static class GameLauncher
+    {
+        public static Task LaunchAsync(GameItem game)
+        {
+            if (game == null)
+                return Task.CompletedTask;
+
+            try
+            {
+                string gameExe = Path.Combine(AppContext.BaseDirectory, "SAM.Game.exe");
+                if (File.Exists(gameExe))
+                {
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = gameExe,
+                        Arguments = game.ID.ToString(CultureInfo.InvariantCulture),
+                        UseShellExecute = true
+                    };
+                    Process.Start(startInfo);
+                }
+            }
+            catch
+            {
+                // Ignore launch failures for now
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/AnSAM/GameListService.cs
+++ b/AnSAM/GameListService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AnSAM
+{
+    public static class GameListService
+    {
+        public static Task<IReadOnlyList<SteamAppData>> LoadGamesAsync()
+        {
+            return Task.FromResult<IReadOnlyList<SteamAppData>>(new List<SteamAppData>());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Launch games from grid via new GameLauncher helper
- Refresh command clears and reloads the game list while updating status UI
- Search box filters results and provides suggestions
- Added GameListService stub for game loading

## Testing
- `dotnet build AnSAM/AnSAM.sln -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a18b01c79c833089daa64738853f06