### PR TITLE
Add Steam client wrapper and hook into UI

### DIFF
--- a/AnSAM/App.xaml.cs
+++ b/AnSAM/App.xaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
+using AnSAM.Steam;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
@@ -27,6 +28,7 @@ namespace AnSAM
     public partial class App : Application
     {
         private Window? _window;
+        private SteamClient? _steamClient;
 
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
@@ -43,7 +45,9 @@ namespace AnSAM
         /// <param name="args">Details about the launch request and process.</param>
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
-            _window = new MainWindow();
+            _steamClient = new SteamClient();
+            _window = new MainWindow(_steamClient);
+            _window.Closed += (_, _) => _steamClient?.Dispose();
             _window.Activate();
         }
     }

--- a/AnSAM/Steam/SteamClient.cs
+++ b/AnSAM/Steam/SteamClient.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace AnSAM.Steam
+{
+    /// <summary>
+    /// Minimal Steamworks client wrapper.
+    /// Initializes the Steam API, pumps callbacks on a timer,
+    /// and exposes a couple of convenience helpers.
+    /// </summary>
+    public sealed class SteamClient : IDisposable
+    {
+        private readonly Timer? _callbackTimer;
+        private readonly IntPtr _apps;
+        private readonly bool _initialized;
+
+        /// <summary>
+        /// Initializes the Steam API and starts the callback pump.
+        /// </summary>
+        public SteamClient()
+        {
+            try
+            {
+                _initialized = SteamAPI_Init();
+                if (_initialized)
+                {
+                    _apps = SteamAPI_SteamApps_v012();
+                    _callbackTimer = new Timer(_ => SteamAPI_RunCallbacks(), null, 0, 100);
+                }
+            }
+            catch
+            {
+                _initialized = false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the current user owns the specified app id.
+        /// </summary>
+        public bool IsSubscribedApp(uint id)
+        {
+            return _initialized && SteamAPI_ISteamApps_BIsSubscribedApp(_apps, id);
+        }
+
+        /// <summary>
+        /// Retrieves a piece of metadata for the given app id.
+        /// Returns null if the key is missing or the client is uninitialized.
+        /// </summary>
+        public string? GetAppData(uint id, string key)
+        {
+            if (!_initialized)
+                return null;
+
+            var sb = new StringBuilder(4096);
+            int len = SteamAPI_ISteamApps_GetAppData(_apps, id, key, sb, sb.Capacity);
+            return len > 0 ? sb.ToString() : null;
+        }
+
+        /// <summary>
+        /// Shuts down the Steam API and stops the callback pump.
+        /// </summary>
+        public void Dispose()
+        {
+            _callbackTimer?.Dispose();
+            if (_initialized)
+            {
+                SteamAPI_Shutdown();
+            }
+        }
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool SteamAPI_Init();
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SteamAPI_RunCallbacks();
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void SteamAPI_Shutdown();
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SteamAPI_SteamApps_v012")]
+        private static extern IntPtr SteamAPI_SteamApps_v012();
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SteamAPI_ISteamApps_BIsSubscribedApp")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        private static extern bool SteamAPI_ISteamApps_BIsSubscribedApp(IntPtr self, uint appId);
+
+        [DllImport("steam_api64", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SteamAPI_ISteamApps_GetAppData")]
+        private static extern int SteamAPI_ISteamApps_GetAppData(IntPtr self,
+                                                                 uint appId,
+                                                                 [MarshalAs(UnmanagedType.LPStr)] string key,
+                                                                 StringBuilder value,
+                                                                 int valueBufferSize);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add minimal Steamworks client using P/Invoke with timer and shutdown
- initialize Steam client in app and use it to populate games

## Testing
- `dotnet build AnSAM/AnSAM.sln -c Release -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a194b717048330892cbe386efd4b31