### PR TITLE
Enhance game search suggestions and navigation

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -108,14 +108,14 @@ namespace AnSAM
             if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
             {
                 var keyword = sender.Text.Trim();
-                var suggestions = string.IsNullOrEmpty(keyword)
+                var matches = string.IsNullOrWhiteSpace(keyword)
                     ? new List<string>()
-                    : _allGames.Where(g => g.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                               .Select(g => g.Title)
-                               .Distinct()
-                               .Take(10)
-                               .ToList();
-                sender.ItemsSource = suggestions;
+                    : Games.Where(g => g.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                           .Select(g => g.Title)
+                           .Distinct()
+                           .Take(10)
+                           .ToList();
+                sender.ItemsSource = matches;
             }
         }
 
@@ -123,7 +123,16 @@ namespace AnSAM
         {
             if (args.SelectedItem is string title)
             {
-                FilterGames(title);
+                var game = Games.FirstOrDefault(g => g.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+                if (game != null)
+                {
+                    GamesView.ScrollIntoView(game);
+                    GamesView.UpdateLayout();
+                    if (GamesView.ContainerFromItem(game) is GridViewItem item)
+                    {
+                        item.Focus(FocusState.Programmatic);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Filter current games to provide top suggestion matches
- Scroll and focus to selected game when choosing a suggestion

## Testing
- `dotnet build AnSAM/AnSAM.sln -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a19e89400c83308b92383f8f8e5c6b