### PR TITLE
Handle errors during refresh

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -61,7 +61,30 @@ namespace AnSAM
 
         private async void OnRefreshClicked(object sender, RoutedEventArgs e)
         {
-            await RefreshAsync();
+            try
+            {
+                await RefreshAsync();
+            }
+            catch (Exception ex)
+            {
+                StatusProgress.IsIndeterminate = false;
+                StatusProgress.Value = 0;
+                StatusExtra.Text = string.Empty;
+                StatusText.Text = "Refresh failed";
+
+                Debug.WriteLine(ex);
+
+                var dialog = new ContentDialog
+                {
+                    Title = "Refresh failed",
+                    Content = "Unable to refresh game list. Please try again.",
+                    CloseButtonText = "OK",
+                    XamlRoot = Content.XamlRoot
+                };
+
+                await dialog.ShowAsync();
+                StatusText.Text = "Ready";
+            }
         }
 
         private async Task RefreshAsync()


### PR DESCRIPTION
## Summary
- wrap refresh click handler in try/catch
- show dialog and reset status indicators when refresh fails

## Testing
- `dotnet build AnSAM/AnSAM.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b9d388f08330a582d0bea88f4e5d