### PR TITLE
Add SAM.Game launch options

### DIFF
--- a/AnSAM/MainWindow.xaml
+++ b/AnSAM/MainWindow.xaml
@@ -62,6 +62,12 @@
                 <GridView.ItemTemplate>
                     <DataTemplate x:DataType="local:GameItem">
                         <StackPanel Width="180" DoubleTapped="GameCard_DoubleTapped">
+                            <StackPanel.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Launch SAM.Game.exe" Click="OnLaunchSamGameClicked"/>
+                                    <MenuFlyoutItem Text="Launch Game" Click="OnLaunchGameClicked"/>
+                                </MenuFlyout>
+                            </StackPanel.ContextFlyout>
                             <Border Height="200" CornerRadius="8"
                             Background="{ThemeResource SystemFillColorSolidNeutralBackgroundBrush}" HorizontalAlignment="Center">
                                 <Image Source="{x:Bind CoverPath}" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"/>

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace AnSAM
             {
                 root.RequestedTheme = theme;
             }
-            // （可選）更新狀態列提示
+            // ]i^sAC
             StatusText.Text = theme switch
             {
                 ElementTheme.Default => "Theme: System default",
@@ -55,7 +55,7 @@ namespace AnSAM
                 _ => "Theme: ?"
             };
 
-            // （可選）持久化使用者選擇
+            // ]i^[い洏峈抰
             //var settings = Windows.Storage.ApplicationData.Current.LocalSettings;
             //settings.Values["AppTheme"] = theme.ToString();
         }
@@ -64,7 +64,7 @@ namespace AnSAM
         private void Theme_Light_Click(object sender, RoutedEventArgs e) => ApplyTheme(ElementTheme.Light);
         private void Theme_Dark_Click(object sender, RoutedEventArgs e) => ApplyTheme(ElementTheme.Dark);
 
-        // （可選）在 MainWindow() 建構式讀回上次選擇：
+        // ]i^b MainWindow() 媞c讀^W隉G
         //if (Windows.Storage.ApplicationData.Current.LocalSettings.Values.TryGetValue("AppTheme", out var t)
         //    && Enum.TryParse<ElementTheme>(t?.ToString(), out var saved)) {
         //    ApplyTheme(saved);
@@ -80,13 +80,44 @@ namespace AnSAM
         {
             if (sender is FrameworkElement element && element.DataContext is GameItem game)
             {
-                StatusText.Text = $"Launching {game.Title}...";
-                StatusProgress.IsIndeterminate = true;
-                StatusExtra.Text = string.Empty;
-                GameLauncher.Launch(game);
-                StatusProgress.IsIndeterminate = false;
-                StatusText.Text = "Ready";
+                StartSamGame(game);
             }
+        }
+
+        private void OnLaunchSamGameClicked(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is GameItem game)
+            {
+                StartSamGame(game);
+            }
+        }
+
+        private void OnLaunchGameClicked(object sender, RoutedEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is GameItem game)
+            {
+                StartGame(game);
+            }
+        }
+
+        private void StartSamGame(GameItem game)
+        {
+            StatusText.Text = $"Launching SAM.Game for {game.Title}...";
+            StatusProgress.IsIndeterminate = true;
+            StatusExtra.Text = string.Empty;
+            GameLauncher.LaunchSamGame(game);
+            StatusProgress.IsIndeterminate = false;
+            StatusText.Text = "Ready";
+        }
+
+        private void StartGame(GameItem game)
+        {
+            StatusText.Text = $"Launching {game.Title}...";
+            StatusProgress.IsIndeterminate = true;
+            StatusExtra.Text = string.Empty;
+            GameLauncher.Launch(game);
+            StatusProgress.IsIndeterminate = false;
+            StatusText.Text = "Ready";
         }
 
         private async void OnRefreshClicked(object sender, RoutedEventArgs e)

--- a/AnSAM/Services/GameLauncher.cs
+++ b/AnSAM/Services/GameLauncher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 
 namespace AnSAM.Services
 {
@@ -41,6 +42,21 @@ namespace AnSAM.Services
             // Fallback to Steam run URL
             var steamUri = $"steam://run/{item.ID.ToString(CultureInfo.InvariantCulture)}";
             TryStart(steamUri);
+        }
+
+        /// <summary>
+        /// Launches SAM.Game.exe for the given <see cref="GameItem"/>.
+        /// </summary>
+        /// <param name="item">Game item containing launch information.</param>
+        public static void LaunchSamGame(GameItem item)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            var samGame = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SAM.Game.exe");
+            TryStart(samGame, item.ID.ToString(CultureInfo.InvariantCulture));
         }
 
         private static bool TryStart(string fileName, string? arguments = null)


### PR DESCRIPTION
## Summary
- launch SAM.Game.exe on double-click
- provide context menu to launch SAM.Game.exe or the game

## Testing
- `dotnet build AnSAM/AnSAM.csproj` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d3093e8c8330890ea1f4599ceea2