### PR TITLE
Gracefully handle missing Steam client

### DIFF
--- a/AnSAM/MainWindow.xaml
+++ b/AnSAM/MainWindow.xaml
@@ -29,7 +29,7 @@
                 </AutoSuggestBox>
             </CommandBar.Content>
             <AppBarSeparator/>
-            <AppBarButton Icon="Sync"   Label="Refresh" Click="OnRefreshClicked"/>
+            <AppBarButton x:Name="RefreshButton" Icon="Sync"   Label="Refresh" Click="OnRefreshClicked"/>
             <AppBarButton Icon="Remove"   Label="Clear Cache" Click="OnClearCacheClicked"/>
             <!-- ▼ 主題切換下拉 -->
             <AppBarButton Icon="Setting" Label="Theme">

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -35,6 +35,11 @@ namespace AnSAM
         {
             _steamClient = steamClient;
             InitializeComponent();
+            RefreshButton.IsEnabled = _steamClient.Initialized;
+            if (!_steamClient.Initialized)
+            {
+                StatusText.Text = "Steam unavailable";
+            }
             GameListService.StatusChanged += OnGameListStatusChanged;
             GameListService.ProgressChanged += OnGameListProgressChanged;
             IconCache.ProgressChanged += OnIconProgressChanged;
@@ -150,6 +155,26 @@ namespace AnSAM
 
         private async Task RefreshAsync()
         {
+            if (!_steamClient.Initialized)
+            {
+                StatusProgress.IsIndeterminate = false;
+                StatusProgress.Value = 0;
+                StatusExtra.Text = string.Empty;
+                StatusText.Text = "Steam unavailable";
+
+                var dialog = new ContentDialog
+                {
+                    Title = "Steam unavailable",
+                    Content = "Unable to refresh because Steam is not available.",
+                    CloseButtonText = "OK",
+                    XamlRoot = Content.XamlRoot
+                };
+
+                await dialog.ShowAsync();
+                RefreshButton.IsEnabled = false;
+                return;
+            }
+
             StatusText.Text = "Refresh";
             StatusProgress.Value = 0;
             StatusExtra.Text = "0%";


### PR DESCRIPTION
## Summary
- Expose initialization state on Steam client
- Disable refresh and show error when Steam is unavailable

## Testing
- `dotnet build AnSAM/AnSAM.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a2da27ba708330986aab9996906784