### PR TITLE
Use Steam metadata to resolve game images

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -213,7 +213,7 @@ namespace AnSAM
                 total++;
                 uint appId = (uint)game.Id;
                 string title = game.Name;
-                IReadOnlyList<string>? coverUrls = null;
+                string? coverUrl = null;
                 if (steamReady)
                 {
                     if (!_steamClient.IsSubscribedApp(appId))
@@ -222,12 +222,9 @@ namespace AnSAM
                     }
                     owned++;
                     title = _steamClient.GetAppData(appId, "name") ?? title;
-                    coverUrls = GameImageUrlResolver.GetGameImageUrls(
-                        (id, key) => _steamClient.GetAppData(id, key),
-                        appId,
-                        "english");
+                    coverUrl = GameImageUrlResolver.GetGameImageUrl(_steamClient, appId, "english");
                 }
-                var data = new SteamAppData(game.Id, title, coverUrls);
+                var data = new SteamAppData(game.Id, title, coverUrl);
                 _allGames.Add(GameItem.FromSteamApp(data));
                 if (steamReady)
                 {
@@ -447,10 +444,10 @@ namespace AnSAM
                                     app.Arguments,
                                     app.UriScheme);
 
-            if (app.CoverUrls is { Count: >0 })
+            if (app.CoverUrl != null)
             {
 #if DEBUG
-                Debug.WriteLine($"Queueing icon download for {app.AppId} from {string.Join(", ", app.CoverUrls)}");
+                Debug.WriteLine($"Queueing icon download for {app.AppId} from {app.CoverUrl}");
 #endif
                 var dispatcher = DispatcherQueue.GetForCurrentThread();
                 _ = LoadIconAsync();
@@ -460,13 +457,16 @@ namespace AnSAM
                     string? path = null;
                     try
                     {
-                        path = await IconCache.GetIconPathAsync(app.AppId, app.CoverUrls);
-#if DEBUG
-                        if (path != null)
+                        if (Uri.TryCreate(app.CoverUrl, UriKind.Absolute, out var uri))
                         {
-                            Debug.WriteLine($"Icon for {app.AppId} stored at {path}");
-                        }
+                            path = await IconCache.GetIconPathAsync(app.AppId, uri);
+#if DEBUG
+                            if (path != null)
+                            {
+                                Debug.WriteLine($"Icon for {app.AppId} stored at {path}");
+                            }
 #endif
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/AnSAM/SteamAppData.cs
+++ b/AnSAM/SteamAppData.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections.Generic;
 
 namespace AnSAM
 {
     public record SteamAppData(int AppId,
                                string Title,
-                               IReadOnlyList<string>? CoverUrls = null,
+                               string? CoverUrl = null,
                                string? ExePath = null,
                                string? Arguments = null,
                                string? UriScheme = null);


### PR DESCRIPTION
## Summary
- Resolve game cover art using Steam metadata via `GameImageUrlResolver`
- Store resolved cover URL in `SteamAppData` during refresh
- Download icons for each game using `IconCache` when available

## Testing
- `dotnet build AnSAM/AnSAM.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet test Legacy/SAM.Picker.Tests/SAM.Picker.Tests.csproj -p:Platform=x64`


------
https://chatgpt.com/codex/tasks/task_e_68a2da316dd48330bac09ac7b2946ffc