### PR TITLE
Use fallback icon when game cover missing

### DIFF
--- a/AnSAM/AnSAM.csproj
+++ b/AnSAM/AnSAM.csproj
@@ -22,6 +22,7 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="no_icon.png" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -537,7 +537,7 @@ namespace AnSAM
 #endif
                     }
 
-                    coverUri ??= new Uri("ms-appx:///Assets/StoreLogo.png");
+                    coverUri ??= new Uri("ms-appx:///no_icon.png");
                     if (dispatcher != null)
                     {
                         _ = dispatcher.TryEnqueue(() => item.CoverPath = coverUri);
@@ -553,7 +553,7 @@ namespace AnSAM
 #if DEBUG
                 Debug.WriteLine($"No icon URL for {app.AppId}");
 #endif
-                item.CoverPath = new Uri("ms-appx:///Assets/StoreLogo.png");
+                item.CoverPath = new Uri("ms-appx:///no_icon.png");
             }
 
             return item;


### PR DESCRIPTION
## Summary
- show placeholder icon when game icon download fails or missing
- include `no_icon.png` in build resources

## Testing
- `dotnet build AnSAM/AnSAM.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a317c8d94c8330b024c5a9f729cffb