### PR TITLE
Log icon path only on download

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -517,14 +517,14 @@ namespace AnSAM
                     {
                         if (Uri.TryCreate(app.CoverUrl, UriKind.Absolute, out var remoteUri))
                         {
-                            var path = await IconCache.GetIconPathAsync(app.AppId, remoteUri);
+                            var result = await IconCache.GetIconPathAsync(app.AppId, remoteUri);
 #if DEBUG
-                            if (path != null)
+                            if (result.Downloaded)
                             {
-                                Debug.WriteLine($"Icon for {app.AppId} stored at {path}");
+                                Debug.WriteLine($"Icon for {app.AppId} stored at {result.Path}");
                             }
 #endif
-                            if (path != null && Uri.TryCreate(path, UriKind.Absolute, out var localUri))
+                            if (Uri.TryCreate(result.Path, UriKind.Absolute, out var localUri))
                             {
                                 coverUri = localUri;
                             }


### PR DESCRIPTION
## Summary
- return a flag from IconCache to indicate whether an icon was freshly downloaded or served from cache
- log stored icon paths in MainWindow only when a download occurs

## Testing
- `dotnet build AnSAM/AnSAM.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a31e742aa8833090c794fc2be68712