### PR TITLE
Support additional icon formats

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../AnSAM/Services/IconCache.cs" Link="IconCache.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+</Project>

--- a/AnSAM.Tests/IconCacheTests.cs
+++ b/AnSAM.Tests/IconCacheTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AnSAM.Services;
+using Xunit;
+
+public class IconCacheTests
+{
+    public static IEnumerable<object[]> ValidHeaders()
+    {
+        yield return new object[] { "bmp", new byte[] { 0x42, 0x4D, 0, 0, 0, 0 } };
+        yield return new object[] { "ico", new byte[] { 0x00, 0x00, 0x01, 0x00, 0, 0 } };
+        yield return new object[] { "avif", new byte[] { 0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66 } };
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidHeaders))]
+    public async Task ValidCachedIconIsUsed(string ext, byte[] data)
+    {
+        var id = Random.Shared.Next(100000, 200000);
+        var cacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "AnSAM", "appcache");
+        Directory.CreateDirectory(cacheDir);
+        foreach (var file in Directory.EnumerateFiles(cacheDir, $"{id}.*"))
+        {
+            try { File.Delete(file); } catch { }
+        }
+        var path = Path.Combine(cacheDir, $"{id}.{ext}");
+        await File.WriteAllBytesAsync(path, data);
+        var uri = new Uri($"http://example.invalid/{id}.{ext}");
+        var result = await IconCache.GetIconPathAsync(id, uri);
+        Assert.Equal(path, result.Path);
+        Assert.False(result.Downloaded);
+        try { File.Delete(path); } catch { }
+    }
+}

--- a/AnSAM/AnSAM.sln
+++ b/AnSAM/AnSAM.sln
@@ -5,8 +5,10 @@ VisualStudioVersion = 17.14.36408.4 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnSAM", "AnSAM.csproj", "{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnSAM.Tests", "..\\AnSAM.Tests\\AnSAM.Tests.csproj", "{A33AB550-B123-4888-B63C-00C5EC30BABF}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -31,9 +33,21 @@ Global
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x64.Build.0 = Release|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x64.Deploy.0 = Release|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.ActiveCfg = Release|x86
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.Build.0 = Release|x86
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.Deploy.0 = Release|x86
-	EndGlobalSection
+                {86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.Build.0 = Release|x86
+                {86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.Deploy.0 = Release|x86
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|ARM64.Build.0 = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x64.Build.0 = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x86.Build.0 = Debug|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|ARM64.ActiveCfg = Release|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|ARM64.Build.0 = Release|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x64.ActiveCfg = Release|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x64.Build.0 = Release|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x86.ActiveCfg = Release|Any CPU
+                {A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/AnSAM/Services/IconCache.cs
+++ b/AnSAM/Services/IconCache.cs
@@ -28,6 +28,10 @@ namespace AnSAM.Services
             ["image/png"] = ".png",
             ["image/gif"] = ".gif",
             ["image/webp"] = ".webp",
+            ["image/bmp"] = ".bmp",
+            ["image/avif"] = ".avif",
+            ["image/x-icon"] = ".ico",
+            ["image/vnd.microsoft.icon"] = ".ico",
         };
 
         private static int _totalRequests;
@@ -192,6 +196,19 @@ namespace AnSAM.Services
                     if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46)
                     {
                         return true; // GIF
+                    }
+                    if (header[0] == 0x42 && header[1] == 0x4D)
+                    {
+                        return true; // BMP
+                    }
+                    if (header[0] == 0x00 && header[1] == 0x00 && header[2] == 0x01 && header[3] == 0x00)
+                    {
+                        return true; // ICO
+                    }
+                    if (read >= 12 && header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70 &&
+                        header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66)
+                    {
+                        return true; // AVIF
                     }
                     if (read >= 12 && header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
                         header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)


### PR DESCRIPTION
## Summary
- handle BMP, ICO, and AVIF signatures when validating cached icons
- map BMP, AVIF, and ICO MIME types to their file extensions
- add tests ensuring cached icons for these formats are used instead of re-downloading

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a320af65e08330b1fa0edde48675a3