### PR TITLE
Optimize cached game lookup

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -259,6 +259,7 @@ namespace AnSAM
                 try
                 {
                     var doc = XDocument.Load(userGamesPath);
+                    var gamesById = GameListService.Games.ToDictionary(g => g.Id);
                     foreach (var node in doc.Root?.Elements("game") ?? Enumerable.Empty<XElement>())
                     {
                         if (!int.TryParse(node.Attribute("id")?.Value, out var id))
@@ -266,7 +267,7 @@ namespace AnSAM
                             continue;
                         }
 
-                        var game = GameListService.Games.FirstOrDefault(g => g.Id == id);
+                        gamesById.TryGetValue(id, out var game);
                         var title = string.IsNullOrEmpty(game.Name)
                             ? id.ToString(CultureInfo.InvariantCulture)
                             : game.Name;


### PR DESCRIPTION
## Summary
- Build dictionary of games keyed by ID before processing cached XML.
- Replace repeated `FirstOrDefault` calls with dictionary lookups for efficiency.

## Testing
- `dotnet test` *(fails: NETSDK1100 requires EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_68a333db7d288330ba017901aab4f787