### PR TITLE
Use loop for search suggestions

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -409,13 +409,27 @@ namespace AnSAM
             if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
             {
                 var keyword = sender.Text.Trim();
-                var matches = string.IsNullOrWhiteSpace(keyword)
-                    ? new List<string>()
-                    : Games.Where(g => g.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                           .Select(g => g.Title)
-                           .Distinct()
-                           .Take(10)
-                           .ToList();
+                List<string> matches;
+                if (string.IsNullOrWhiteSpace(keyword))
+                {
+                    matches = new List<string>();
+                }
+                else
+                {
+                    var titles = new HashSet<string>();
+                    matches = new List<string>();
+                    foreach (var game in Games)
+                    {
+                        if (game.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase) && titles.Add(game.Title))
+                        {
+                            matches.Add(game.Title);
+                            if (matches.Count == 10)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
                 sender.ItemsSource = matches;
             }
         }


### PR DESCRIPTION
## Summary
- Replace LINQ-based search suggestions with a single-pass loop that collects up to ten unique game titles

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a33916633083308d9e369b56ebe580