### PR TITLE
Stream XML parsing in GameListService

### DIFF
--- a/AnSAM/Services/GameListService.cs
+++ b/AnSAM/Services/GameListService.cs
@@ -128,29 +128,35 @@ namespace AnSAM.Services
             };
 
             using var reader = XmlReader.Create(ms, settings);
+            reader.MoveToContent();
 
             var parsed = new List<GameInfo>();
-            while (reader.ReadToFollowing("game"))
+            if (reader.ReadToDescendant("game"))
             {
-                var raw = reader.ReadElementContentAsString()?.Trim();
-                if (string.IsNullOrEmpty(raw))
+                while (reader.NodeType == XmlNodeType.Element && reader.Name == "game")
                 {
+                    var raw = reader.ReadElementContentAsString().Trim();
+                    if (string.IsNullOrEmpty(raw))
+                    {
 #if DEBUG
-                    Debug.WriteLine("Skipping empty <game> entry in XML");
+                        Debug.WriteLine("Skipping empty <game> entry in XML");
 #endif
-                    continue;
-                }
+                        reader.MoveToContent();
+                        continue;
+                    }
 
-                if (int.TryParse(raw, out int id) && id > 0)
-                {
-                    parsed.Add(new GameInfo(id, string.Empty, string.Empty));
-                }
+                    if (int.TryParse(raw, out int id) && id > 0)
+                    {
+                        parsed.Add(new GameInfo(id, string.Empty, string.Empty));
+                    }
 #if DEBUG
-                else
-                {
-                    Debug.WriteLine($"Invalid game id '{raw}' in XML");
-                }
+                    else
+                    {
+                        Debug.WriteLine($"Invalid game id '{raw}' in XML");
+                    }
 #endif
+                    reader.MoveToContent();
+                }
             }
 
             Games = parsed;


### PR DESCRIPTION
## Summary
- Parse SAM game list using `XmlReader` to handle `<game>` entries sequentially and avoid building a full DOM
- Drop unused `System.Xml.Linq` dependency

## Testing
- `dotnet build AnSAM/AnSAM.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a33ef3fbd483308370bb5f368daa33