### PR TITLE
Preload cached game list before refreshing

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -251,8 +251,7 @@ namespace AnSAM
             Games.Clear();
             _allGames.Clear();
 
-            using var http = new HttpClient();
-            await GameListService.LoadAsync(cacheDir, http);
+            GameListService.TryLoadCache(cacheDir);
 
             if (File.Exists(userGamesPath))
             {
@@ -289,6 +288,12 @@ namespace AnSAM
 #endif
                 }
             }
+
+            StatusProgress.Value = 0;
+            StatusExtra.Text = "0%";
+
+            using var http = new HttpClient();
+            await GameListService.LoadAsync(cacheDir, http);
 
             Games.Clear();
             _allGames.Clear();

--- a/AnSAM/Services/GameListService.cs
+++ b/AnSAM/Services/GameListService.cs
@@ -100,6 +100,34 @@ namespace AnSAM.Services
             return data;
         }
 
+        /// <summary>
+        /// Attempts to load and parse the cached game list if it is still fresh.
+        /// </summary>
+        /// <param name="baseDir">Directory containing the cached file.</param>
+        /// <returns>True if a recent cache was loaded and parsed.</returns>
+        public static bool TryLoadCache(string baseDir)
+        {
+            var cachePath = Path.Combine(baseDir, CacheFileName);
+            try
+            {
+                if (!TryGetValidCache(cachePath, out var data))
+                {
+                    Games = Array.Empty<GameInfo>();
+                    return false;
+                }
+
+                ValidateAndParse(data);
+                ReportStatus("Using cached game list...");
+                ReportProgress(100);
+                return true;
+            }
+            catch
+            {
+                Games = Array.Empty<GameInfo>();
+                return false;
+            }
+        }
+
         private static bool TryGetValidCache(string cachePath, out byte[] data)
         {
             data = Array.Empty<byte>();


### PR DESCRIPTION
## Summary
- add `GameListService.TryLoadCache` to parse cached game list when the file is under 30 minutes old
- preload cached user game IDs in `RefreshAsync` before network calls, then refresh from Steam and rewrite cache

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3d9a9eb6c833095b0c6a64aba2135