### PR TITLE
Use temp file for game list replacement

### DIFF
--- a/AnSAM/Services/GameListService.cs
+++ b/AnSAM/Services/GameListService.cs
@@ -91,10 +91,35 @@ namespace AnSAM.Services
             var data = ms.ToArray();
             ValidateAndParse(data);
 
-            await File.WriteAllBytesAsync(cachePath, data).ConfigureAwait(false);
+            var tempPath = cachePath + ".tmp";
+            try
+            {
+                await File.WriteAllBytesAsync(tempPath, data).ConfigureAwait(false);
+                if (File.Exists(cachePath))
+                {
+                    File.Replace(tempPath, cachePath, null);
+                }
+                else
+                {
+                    File.Move(tempPath, cachePath);
+                }
 #if DEBUG
-            Debug.WriteLine($"Game list saved to {cachePath}");
+                Debug.WriteLine($"Game list saved to {cachePath}");
 #endif
+            }
+            catch
+            {
+                try
+                {
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
+                }
+                catch { }
+
+                throw;
+            }
             ReportStatus("Game list downloaded.");
             ReportProgress(100);
             return data;


### PR DESCRIPTION
## Summary
- write downloaded game list to a temporary file before replacing cache
- remove temporary file if an error occurs

## Testing
- `dotnet test AnSAM/AnSAM.sln` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e802cb3483309f1fff0a428d2fee