### PR TITLE
Disable SAM.Game menu when executable missing

### DIFF
--- a/AnSAM/MainWindow.xaml
+++ b/AnSAM/MainWindow.xaml
@@ -64,7 +64,7 @@
                         <StackPanel Width="231" DoubleTapped="GameCard_DoubleTapped">
                             <StackPanel.ContextFlyout>
                                 <MenuFlyout>
-                                    <MenuFlyoutItem Text="Launch SAM.Game.exe" Click="OnLaunchSamGameClicked"/>
+                                    <MenuFlyoutItem Text="Launch SAM.Game.exe" Click="OnLaunchSamGameClicked" IsEnabled="{x:Bind IsSamGameAvailable}"/>
                                     <MenuFlyoutItem Text="Launch Game" Click="OnLaunchGameClicked"/>
                                 </MenuFlyout>
                             </StackPanel.ContextFlyout>

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -197,7 +197,14 @@ namespace AnSAM
         {
             if (sender is FrameworkElement element && element.DataContext is GameItem game)
             {
-                StartSamGame(game);
+                if (game.IsSamGameAvailable)
+                {
+                    StartSamGame(game);
+                }
+                else
+                {
+                    StatusText.Text = "SAM.Game.exe not found";
+                }
             }
         }
 
@@ -205,7 +212,14 @@ namespace AnSAM
         {
             if (sender is FrameworkElement element && element.DataContext is GameItem game)
             {
-                StartSamGame(game);
+                if (game.IsSamGameAvailable)
+                {
+                    StartSamGame(game);
+                }
+                else
+                {
+                    StatusText.Text = "SAM.Game.exe not found";
+                }
             }
         }
 
@@ -517,6 +531,7 @@ namespace AnSAM
         public string? ExePath { get; set; }
         public string? Arguments { get; set; }
         public string? UriScheme { get; set; }
+        public bool IsSamGameAvailable => GameLauncher.IsSamGameAvailable;
 
         public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
 


### PR DESCRIPTION
## Summary
- expose SAM.Game availability through `GameItem`
- disable "Launch SAM.Game.exe" when SAM.Game is missing
- show status message instead of trying to launch when SAM.Game.exe absent

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj -p:EnableWindowsTargeting=true`
- `dotnet build AnSAM/AnSAM.csproj -p:EnableWindowsTargeting=true` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa710a148330ac4fcc672b9f4100