### PR TITLE
Use system accent colors for title bar

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -117,7 +117,11 @@ namespace AnSAM
             var accentDark2 = _uiSettings.GetColorValue(UIColorType.AccentDark2);
             var accentLight1 = _uiSettings.GetColorValue(UIColorType.AccentLight1);
             var foreground = _uiSettings.GetColorValue(UIColorType.Foreground);
-            var grayText = _uiSettings.GetColorValue(UIColorType.GrayText);
+            var inactiveForeground = Color.FromArgb(
+                foreground.A,
+                (byte)(foreground.R / 2),
+                (byte)(foreground.G / 2),
+                (byte)(foreground.B / 2));
 
             if (theme == ElementTheme.Dark)
             {
@@ -132,9 +136,9 @@ namespace AnSAM
                 titleBar.ButtonPressedForegroundColor = foreground;
 
                 titleBar.InactiveBackgroundColor = accentDark2;
-                titleBar.InactiveForegroundColor = grayText;
+                titleBar.InactiveForegroundColor = inactiveForeground;
                 titleBar.ButtonInactiveBackgroundColor = accentDark2;
-                titleBar.ButtonInactiveForegroundColor = grayText;
+                titleBar.ButtonInactiveForegroundColor = inactiveForeground;
             }
             else
             {
@@ -149,9 +153,9 @@ namespace AnSAM
                 titleBar.ButtonPressedForegroundColor = foreground;
 
                 titleBar.InactiveBackgroundColor = accentLight1;
-                titleBar.InactiveForegroundColor = grayText;
+                titleBar.InactiveForegroundColor = inactiveForeground;
                 titleBar.ButtonInactiveBackgroundColor = accentLight1;
-                titleBar.ButtonInactiveForegroundColor = grayText;
+                titleBar.ButtonInactiveForegroundColor = inactiveForeground;
             }
         }
 


### PR DESCRIPTION
## Summary
- derive accent color brushes from `UISettings`
- apply system accent colors to title bar buttons
- refresh colors when Windows custom theme changes

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a40ccb79b8833080f3ec495670e787