### PR TITLE
chore: unify output paths and drop non-x64 targets

### DIFF
--- a/AnSAM.sln
+++ b/AnSAM.sln
@@ -10,61 +10,27 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnSAM_RunGame", "AnSAM_RunGame\AnSAM_RunGame.csproj", "{B12F8C5D-123A-4567-89AB-1234567890CD}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM64 = Debug|ARM64
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|ARM64 = Release|ARM64
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|x64 = Debug|x64
+                Release|x64 = Release|x64
+        EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|ARM64.Build.0 = Debug|ARM64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x64.ActiveCfg = Debug|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x64.Build.0 = Debug|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x64.Deploy.0 = Debug|x64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x86.ActiveCfg = Debug|x86
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x86.Build.0 = Debug|x86
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Debug|x86.Deploy.0 = Debug|x86
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|ARM64.ActiveCfg = Release|ARM64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|ARM64.Build.0 = Release|ARM64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|ARM64.Deploy.0 = Release|ARM64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x64.ActiveCfg = Release|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x64.Build.0 = Release|x64
 		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x64.Deploy.0 = Release|x64
-		{86B12DC3-BB8A-44A7-8FAC-9C61A71E1C25}.Release|x86.ActiveCfg = Release|x86
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|ARM64.ActiveCfg = Debug|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|ARM64.Build.0 = Debug|Any CPU
 		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x64.Build.0 = Debug|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Debug|x86.Build.0 = Debug|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|ARM64.ActiveCfg = Release|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|ARM64.Build.0 = Release|Any CPU
 		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x64.ActiveCfg = Release|Any CPU
 		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x64.Build.0 = Release|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x86.ActiveCfg = Release|Any CPU
-		{A33AB550-B123-4888-B63C-00C5EC30BABF}.Release|x86.Build.0 = Release|Any CPU
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|ARM64.Build.0 = Debug|ARM64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x64.ActiveCfg = Debug|x64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x64.Build.0 = Debug|x64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x64.Deploy.0 = Debug|x64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x86.ActiveCfg = Debug|x86
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x86.Build.0 = Debug|x86
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Debug|x86.Deploy.0 = Debug|x86
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|ARM64.ActiveCfg = Release|ARM64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|ARM64.Build.0 = Release|ARM64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|ARM64.Deploy.0 = Release|ARM64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x64.ActiveCfg = Release|x64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x64.Build.0 = Release|x64
 		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x64.Deploy.0 = Release|x64
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x86.ActiveCfg = Release|x86
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x86.Build.0 = Release|x86
-		{B12F8C5D-123A-4567-89AB-1234567890CD}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,3 +39,4 @@ Global
 		SolutionGuid = {0427E820-7FC9-424F-AC94-0086FAC88308}
 	EndGlobalSection
 EndGlobal
+

--- a/AnSAM/AnSAM.csproj
+++ b/AnSAM/AnSAM.csproj
@@ -5,9 +5,9 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>AnSAM</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishProfile>win-x64.pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
@@ -68,20 +68,12 @@
   </PropertyGroup>
   <!-- Output Directory Configuration -->
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <OutputPath>..\output\Debug\$(Platform)\</OutputPath>
+    <OutputPath>..\output\Debug\</OutputPath>
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <OutputPath>..\output\Release\$(Platform)\</OutputPath>
+    <OutputPath>..\output\Release\</OutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
+  
 </Project>

--- a/AnSAM_RunGame/AnSAM_RunGame.csproj
+++ b/AnSAM_RunGame/AnSAM_RunGame.csproj
@@ -5,9 +5,9 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>AnSAM.RunGame</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishProfile>win-x64.pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
@@ -50,20 +50,12 @@
   
   <!-- Output Directory Configuration -->
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <OutputPath>..\output\Debug\$(Platform)\</OutputPath>
+    <OutputPath>..\output\Debug\</OutputPath>
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <OutputPath>..\output\Release\$(Platform)\</OutputPath>
+    <OutputPath>..\output\Release\</OutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
-  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- build only x64 in AnSAM solution
- send AnSAM & AnSAM_RunGame outputs to shared `output/Debug` and `output/Release`

## Testing
- `dotnet test AnSAM.sln -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a45b0cdcc48330b4d78704a4a3e912