### PR TITLE
Add debug logs for user stats request issues

### DIFF
--- a/AnSAM_RunGame/MainWindow.xaml.cs
+++ b/AnSAM_RunGame/MainWindow.xaml.cs
@@ -118,13 +118,16 @@ namespace AnSAM.RunGame
             _isLoadingStats = true;
             LoadingRing.IsActive = true;
             StatusLabel.Text = "Loading game statistics...";
-            
+
             try
             {
+                DebugLogger.LogDebug("LoadStatsAsync: Requesting user stats...");
                 bool success = await _gameStatsService.RequestUserStatsAsync();
+                DebugLogger.LogDebug($"LoadStatsAsync: RequestUserStatsAsync returned {success}");
                 if (!success)
                 {
                     StatusLabel.Text = "Failed to request user stats from Steam";
+                    DebugLogger.LogDebug("LoadStatsAsync: Failed to request user stats from Steam");
                 }
             }
             catch (Exception ex)

--- a/AnSAM_RunGame/Services/GameStatsService.cs
+++ b/AnSAM_RunGame/Services/GameStatsService.cs
@@ -161,7 +161,10 @@ namespace AnSAM.RunGame.Services
 
         public async Task<bool> RequestUserStatsAsync()
         {
-            return await Task.Run(() => _steamClient.RequestUserStats((uint)_gameId));
+            DebugLogger.LogDebug($"GameStatsService.RequestUserStatsAsync called for game {_gameId}");
+            bool result = await Task.Run(() => _steamClient.RequestUserStats((uint)_gameId));
+            DebugLogger.LogDebug($"GameStatsService.RequestUserStatsAsync result: {result}");
+            return result;
         }
         
         public string GetCurrentGameLanguage()

--- a/AnSAM_RunGame/Steam/SteamGameClient.cs
+++ b/AnSAM_RunGame/Steam/SteamGameClient.cs
@@ -153,10 +153,27 @@ namespace AnSAM.RunGame.Steam
 
         public bool RequestUserStats(uint gameId)
         {
-            if (!Initialized || _requestUserStats == null || _getSteamId == null) return false;
-            
+            if (!Initialized)
+            {
+                DebugLogger.LogDebug($"SteamGameClient.RequestUserStats failed: client not initialized (gameId={gameId})");
+                return false;
+            }
+            if (_requestUserStats == null)
+            {
+                DebugLogger.LogDebug("SteamGameClient.RequestUserStats failed: _requestUserStats delegate is null");
+                return false;
+            }
+            if (_getSteamId == null)
+            {
+                DebugLogger.LogDebug("SteamGameClient.RequestUserStats failed: _getSteamId delegate is null");
+                return false;
+            }
+
             ulong steamId = _getSteamId(_user006);
-            return _requestUserStats(_userStats, steamId) != 0;
+            DebugLogger.LogDebug($"SteamGameClient.RequestUserStats calling for game {gameId} (steamId={steamId})");
+            bool result = _requestUserStats(_userStats, steamId) != 0;
+            DebugLogger.LogDebug($"SteamGameClient.RequestUserStats result for game {gameId}: {result}");
+            return result;
         }
 
         public bool GetAchievementAndUnlockTime(string id, out bool achieved, out uint unlockTime)


### PR DESCRIPTION
## Summary
- Log user stat request attempts and results in GameStatsService and SteamGameClient
- Emit detailed debug messages when user stats request fails in MainWindow

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a46056c65c8330bcb2af1408f67a05