### PR TITLE
Use DebugLogger in IconCache

### DIFF
--- a/AnSAM/Services/IconCache.cs
+++ b/AnSAM/Services/IconCache.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
+using AnSAM.Services;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -78,7 +78,7 @@ namespace AnSAM.Services
                     if (IsCacheValid(path))
                     {
 #if DEBUG
-                        Debug.WriteLine($"Using cached icon for {id} at {path}");
+                        DebugLogger.LogDebug($"Using cached icon for {id} at {path}");
 #endif
                         return Task.FromResult(new IconPathResult(path, false));
                     }
@@ -114,7 +114,7 @@ namespace AnSAM.Services
                     catch (HttpRequestException ex)
                     {
 #if DEBUG
-                        Debug.WriteLine($"Icon download failed for {id}: {ex.Message}");
+                        DebugLogger.LogDebug($"Icon download failed for {id}: {ex.Message}");
 #endif
                     }
                 }
@@ -140,7 +140,7 @@ namespace AnSAM.Services
 
                 var path = basePath + ext;
 #if DEBUG
-                Debug.WriteLine($"Downloading icon {uri} -> {path}");
+                DebugLogger.LogDebug($"Downloading icon {uri} -> {path}");
 #endif
                 await using (var fs = File.Create(path))
                 {
@@ -158,7 +158,7 @@ namespace AnSAM.Services
             catch (Exception ex)
             {
 #if DEBUG
-                Debug.WriteLine($"Icon download failed: {ex.Message}");
+                DebugLogger.LogDebug($"Icon download failed: {ex.Message}");
 #endif
                 throw;
             }


### PR DESCRIPTION
## Summary
- replace Debug.WriteLine calls with DebugLogger.LogDebug in IconCache
- add missing namespace import for DebugLogger

## Testing
- `dotnet build AnSAM.sln` *(fails: NETSDK1100 EnableWindowsTargeting)*
- `dotnet test AnSAM.sln` *(fails: NETSDK1100 EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_68a4735fbf188330b0418391e752599b