### PR TITLE
Use DebugLogger for SteamGameClient init errors

### DIFF
--- a/AnSAM_RunGame/Steam/SteamGameClient.cs
+++ b/AnSAM_RunGame/Steam/SteamGameClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -147,7 +146,7 @@ namespace AnSAM.RunGame.Steam
             catch (Exception ex)
             {
                 Initialized = false;
-                Debug.WriteLine($"Steam API init threw: {ex}");
+                DebugLogger.LogDebug($"Steam API init threw: {ex}");
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace `Debug.WriteLine` with `DebugLogger.LogDebug` in `SteamGameClient`
- Remove unnecessary `System.Diagnostics` import

## Testing
- `dotnet test` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set EnableWindowsTargeting to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a4736d1d208330a4dd44267e67fea0