### PR TITLE
Add tooltips to RunGame command bar buttons

### DIFF
--- a/RunGame/MainWindow.xaml
+++ b/RunGame/MainWindow.xaml
@@ -12,15 +12,15 @@
 
         <!-- Top CommandBar -->
         <CommandBar Grid.Row="0">
-            <AppBarButton x:Name="RefreshButton" Icon="Refresh" Label="Refresh" Click="OnRefresh"/>
-            <AppBarButton x:Name="StoreButton" Icon="Save" Label="Store" Click="OnStore"/>
+            <AppBarButton x:Name="RefreshButton" Icon="Refresh" Label="Refresh" Click="OnRefresh" ToolTipService.ToolTip="Refresh"/>
+            <AppBarButton x:Name="StoreButton" Icon="Save" Label="Store" Click="OnStore" ToolTipService.ToolTip="Store"/>
             <AppBarSeparator/>
-            <AppBarButton x:Name="LockAllButton" Icon="DisableUpdates" Label="Lock All" Click="OnLockAll"/>
-            <AppBarButton x:Name="UnlockAllButton" Icon="Pin" Label="Unlock All" Click="OnUnlockAll"/>
-            <AppBarButton x:Name="InvertAllButton" Icon="Switch" Label="Invert All" Click="OnInvertAll"/>
-            <AppBarButton x:Name="ResetStatsButton" Icon="Delete" Label="Reset Stats" Click="OnResetAllStats"/>
-            <AppBarButton x:Name="AutoMouseMoveButton" Icon="Target" Label="Auto Mouse" Click="OnAutoMouseMove"/>
-            <AppBarToggleButton x:Name="TimerToggleButton" Icon="Clock" Label="Timer" Click="OnTimerToggle"/>
+            <AppBarButton x:Name="LockAllButton" Icon="DisableUpdates" Label="Lock All" Click="OnLockAll" ToolTipService.ToolTip="Lock All"/>
+            <AppBarButton x:Name="UnlockAllButton" Icon="Pin" Label="Unlock All" Click="OnUnlockAll" ToolTipService.ToolTip="Unlock All"/>
+            <AppBarButton x:Name="InvertAllButton" Icon="Switch" Label="Invert All" Click="OnInvertAll" ToolTipService.ToolTip="Invert All"/>
+            <AppBarButton x:Name="ResetStatsButton" Icon="Delete" Label="Reset Stats" Click="OnResetAllStats" ToolTipService.ToolTip="Reset Stats"/>
+            <AppBarButton x:Name="AutoMouseMoveButton" Icon="Target" Label="Auto Mouse" Click="OnAutoMouseMove" ToolTipService.ToolTip="Auto Mouse"/>
+            <AppBarToggleButton x:Name="TimerToggleButton" Icon="Clock" Label="Timer" Click="OnTimerToggle" ToolTipService.ToolTip="Timer"/>
         </CommandBar>
 
         <!-- Main Content -->


### PR DESCRIPTION
## Summary
- add ToolTipService.ToolTip to RunGame CommandBar buttons for better usability

## Testing
- `dotnet build RunGame/RunGame.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5558a72e0833094137a3e1a50b424