### PR TITLE
Update achievement icons on state change

### DIFF
--- a/RunGame/MainWindow.xaml.cs
+++ b/RunGame/MainWindow.xaml.cs
@@ -829,8 +829,10 @@ namespace RunGame
                 foreach (var achievement in _achievements)
                 {
                     // Get the appropriate icon filename based on achievement state
-                    string iconFileName = achievement.IsAchieved ? achievement.IconNormal : achievement.IconLocked;
-                    
+                    string iconFileName = achievement.IsAchieved || string.IsNullOrEmpty(achievement.IconLocked)
+                        ? achievement.IconNormal
+                        : achievement.IconLocked;
+
                     if (!string.IsNullOrEmpty(iconFileName))
                     {
                         var iconPath = await _achievementIconService.GetAchievementIconAsync(
@@ -867,7 +869,9 @@ namespace RunGame
             if (e.PropertyName != nameof(AchievementInfo.IsAchieved)) return;
             if (sender is not AchievementInfo achievement) return;
 
-            string iconFileName = achievement.IsAchieved ? achievement.IconNormal : achievement.IconLocked;
+            string iconFileName = achievement.IsAchieved || string.IsNullOrEmpty(achievement.IconLocked)
+                ? achievement.IconNormal
+                : achievement.IconLocked;
             if (string.IsNullOrEmpty(iconFileName)) return;
 
             try

--- a/RunGame/Models/AchievementInfo.cs
+++ b/RunGame/Models/AchievementInfo.cs
@@ -36,7 +36,10 @@ namespace RunGame.Models
         public string IconNormal { get; set; } = string.Empty;
         public string IconLocked { get; set; } = string.Empty;
         public int Permission { get; set; }
-        public string IconUrl => IsAchieved ? IconNormal : IconLocked;
+        public string IconUrl =>
+            IsAchieved
+                ? IconNormal
+                : string.IsNullOrEmpty(IconLocked) ? IconNormal : IconLocked;
         public bool IsProtected => (Permission & 3) != 0;
         public Visibility LockVisibility => IsProtected && !IsAchieved ? Visibility.Visible : Visibility.Collapsed;
         

--- a/RunGame/Services/GameStatsService.cs
+++ b/RunGame/Services/GameStatsService.cs
@@ -365,7 +365,7 @@ namespace RunGame.Services
                             ? DateTimeOffset.FromUnixTimeSeconds(unlockTime).LocalDateTime 
                             : null,
                         IconNormal = def.IconNormal,
-                        IconLocked = def.IconLocked,
+                        IconLocked = string.IsNullOrEmpty(def.IconLocked) ? def.IconNormal : def.IconLocked,
                         Permission = def.Permission
                     };
                     


### PR DESCRIPTION
## Summary
- subscribe to `PropertyChanged` for achievements when loaded
- refresh achievement icon when `IsAchieved` toggles

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a562aafc688330a52112a4a8b83e6b