### PR TITLE
Pre-initialize LocalSettings on UI thread

### DIFF
--- a/RunGame/App.xaml.cs
+++ b/RunGame/App.xaml.cs
@@ -1,10 +1,13 @@
 using Microsoft.UI.Xaml;
 using System;
+using Windows.Storage;
 
 namespace RunGame
 {
     public partial class App : Application
     {
+        internal static ApplicationDataContainer? LocalSettings { get; private set; }
+
         public App()
         {
             this.InitializeComponent();
@@ -12,6 +15,15 @@ namespace RunGame
 
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
+            try
+            {
+                LocalSettings = ApplicationData.Current.LocalSettings;
+            }
+            catch (InvalidOperationException)
+            {
+                LocalSettings = null;
+            }
+
             var cmdArgs = Environment.GetCommandLineArgs();
             
             if (cmdArgs.Length < 2)

--- a/RunGame/MainWindow.xaml.cs
+++ b/RunGame/MainWindow.xaml.cs
@@ -215,14 +215,7 @@ namespace RunGame
         private static ApplicationDataContainer? TryGetLocalSettings()
         {
             DebugLogger.LogDebug("TryGetLocalSettings() Start");
-            try
-            {
-                return ApplicationData.Current.LocalSettings;
-            }
-            catch (InvalidOperationException)
-            {
-                return null;
-            }
+            return App.LocalSettings;
         }
 
         private void InitializeLanguageComboBox()


### PR DESCRIPTION
## Summary
- Cache `ApplicationData.Current.LocalSettings` during launch to ensure it's initialized on the UI thread
- Expose cached settings via `App.LocalSettings`
- Replace direct LocalSettings access with use of `App.LocalSettings`

## Testing
- `dotnet test` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a5795755e0833084a30b685d4f9943