### PR TITLE
Initialize theme based on saved preference or system setting

### DIFF
--- a/AnSAM/App.xaml.cs
+++ b/AnSAM/App.xaml.cs
@@ -35,7 +35,7 @@ namespace AnSAM
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             var theme = LoadThemePreference() ?? GetSystemTheme();
-            this.RequestedTheme = theme;
+            this.RequestedTheme = ToApplicationTheme(theme);
 
             _steamClient = new SteamClient();
             _window = new MainWindow(_steamClient, theme);
@@ -61,7 +61,7 @@ namespace AnSAM
             return null;
         }
 
-        private static ElementTheme GetSystemTheme()
+        internal static ElementTheme GetSystemTheme()
         {
             try
             {
@@ -77,6 +77,12 @@ namespace AnSAM
                 // Fall back to light theme if the registry is unavailable
             }
             return ElementTheme.Light;
+        }
+
+        internal static ApplicationTheme ToApplicationTheme(ElementTheme theme)
+        {
+            var resolved = theme == ElementTheme.Default ? GetSystemTheme() : theme;
+            return resolved == ElementTheme.Dark ? ApplicationTheme.Dark : ApplicationTheme.Light;
         }
     }
 }

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -63,12 +63,11 @@ namespace AnSAM
 
             if (Content is FrameworkElement root)
             {
-                root.KeyDown += OnWindowKeyDown;
                 ApplyTheme(theme, save: false);
+                root.KeyDown += OnWindowKeyDown;
                 if (AppWindowTitleBar.IsCustomizationSupported())
                 {
                     root.ActualThemeChanged += (_, _) => UpdateTitleBar(root.ActualTheme);
-                    UpdateTitleBar(root.ActualTheme);
                 }
             }
 
@@ -88,6 +87,7 @@ namespace AnSAM
             {
                 root.RequestedTheme = theme;
                 ApplyAccentBrush(root);
+                UpdateTitleBar(theme);
             }
 
             StatusText.Text = theme switch
@@ -111,7 +111,7 @@ namespace AnSAM
                 }
             }
 
-            ((App)Application.Current).RequestedTheme = theme;
+            ((App)Application.Current).RequestedTheme = App.ToApplicationTheme(theme);
         }
         private void Theme_Default_Click(object sender, RoutedEventArgs e) => ApplyTheme(ElementTheme.Default);
         private void Theme_Light_Click(object sender, RoutedEventArgs e) => ApplyTheme(ElementTheme.Light);


### PR DESCRIPTION
## Summary
- load saved theme or system default during app launch
- apply theme at app level and propagate to MainWindow
- persist theme changes and update resources immediately

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: /root/.nuget/packages/microsoft.windowsappsdk/.../XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a57be2b0388330a4353630a59af919