### PR TITLE
Skip storing stats in debug builds

### DIFF
--- a/RunGame/MainWindow.xaml.cs
+++ b/RunGame/MainWindow.xaml.cs
@@ -377,7 +377,21 @@ namespace RunGame
             try
             {
                 DebugLogger.LogDebug($"PerformStore called (silent: {silent})");
-                
+
+#if DEBUG
+                // In debug builds, skip storing to Steam to avoid modifying real data
+                if (!silent)
+                {
+                    StatusLabel.Text = "Store skipped in debug mode";
+                }
+                else
+                {
+                    _ = LoadStatsAsync(); // Refresh to reflect any local changes
+                }
+                DebugLogger.LogDebug("Store operation skipped in debug mode");
+                return;
+#endif
+
                 int achievementCount = StoreAchievements(silent);
                 if (achievementCount < 0) return;
 


### PR DESCRIPTION
## Summary
- Avoid storing achievements and statistics when running RunGame in debug mode by short-circuiting the store routine

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*


------
https://chatgpt.com/codex/tasks/task_e_68a57c3e3e688330bd1cef3ab4cc65a5