### PR TITLE
Handle console IO errors in DebugLogger

### DIFF
--- a/RunGame/Services/DebugLogger.cs
+++ b/RunGame/Services/DebugLogger.cs
@@ -30,8 +30,26 @@ namespace RunGame.Services
             var logMessage = $"[{timestamp}] DEBUG: {message}";
             
             // 輸出到控制台
-            Debug.WriteLine(logMessage);
-            Console.WriteLine(logMessage);
+            try
+            {
+                Debug.WriteLine(logMessage);
+            }
+            catch
+            {
+                // 忽略調試輸出錯誤
+            }
+
+            if (Environment.UserInteractive || Debugger.IsAttached)
+            {
+                try
+                {
+                    Console.WriteLine(logMessage);
+                }
+                catch (IOException)
+                {
+                    // 忽略控制台輸出錯誤
+                }
+            }
             
             // 寫入到日誌文件
             try


### PR DESCRIPTION
## Summary
- prevent console logging failures in `DebugLogger`
- ignore all debug logging errors and gate console output on user interaction or debugger attachment

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a68a9ce6608330883cd1d9fc2ef10c