### PR TITLE
Ensure DebugLogger output never disrupts application flow

### DIFF
--- a/AnSAM/Services/DebugLogger.cs
+++ b/AnSAM/Services/DebugLogger.cs
@@ -28,8 +28,26 @@ namespace AnSAM.Services
             var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             var logMessage = $"[{timestamp}] DEBUG: {message}";
 
-            Debug.WriteLine(logMessage);
-            Console.WriteLine(logMessage);
+            try
+            {
+                Debug.WriteLine(logMessage);
+            }
+            catch
+            {
+                // 忽略日誌輸出錯誤
+            }
+
+            if (Environment.UserInteractive || Debugger.IsAttached)
+            {
+                try
+                {
+                    Console.WriteLine(logMessage);
+                }
+                catch
+                {
+                    // 忽略日誌輸出錯誤
+                }
+            }
 
             try
             {


### PR DESCRIPTION
## Summary
- Wrap `Debug.WriteLine` and `Console.WriteLine` in `try/catch` blocks
- Only write to console when `Environment.UserInteractive` or a debugger is attached
- Preserve file logging within `try/catch` to avoid application interruptions

## Testing
- `dotnet test` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a33933a88330b69eb4d2a60222cf