### PR TITLE
Use shared DebugLogger in MyOwnGames

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -150,7 +150,7 @@ namespace MyOwnGames
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error loading image for {appId}: {ex.Message}");
+                DebugLogger.LogDebug($"Error loading image for {appId}: {ex.Message}");
             }
         }
 

--- a/MyOwnGames/Services/DebugLogger.cs
+++ b/MyOwnGames/Services/DebugLogger.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace MyOwnGames.Services
+{
+    public static class DebugLogger
+    {
+        private static readonly string LogFilePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "MyOwnGames", "debug.log");
+
+        static DebugLogger()
+        {
+            // 確保日誌目錄存在
+            var logDir = Path.GetDirectoryName(LogFilePath);
+            if (!string.IsNullOrEmpty(logDir) && !Directory.Exists(logDir))
+            {
+                Directory.CreateDirectory(logDir);
+            }
+        }
+
+        /// <summary>
+        /// 記錄調試信息（僅在 Debug 模式下輸出）
+        /// </summary>
+        public static void LogDebug(string message)
+        {
+#if DEBUG
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            var logMessage = $"[{timestamp}] DEBUG: {message}";
+            
+            // 輸出到控制台
+            try
+            {
+                Debug.WriteLine(logMessage);
+            }
+            catch
+            {
+                // 忽略調試輸出錯誤
+            }
+
+            if (Environment.UserInteractive || Debugger.IsAttached)
+            {
+                try
+                {
+                    Console.WriteLine(logMessage);
+                }
+                catch (IOException)
+                {
+                    // 忽略控制台輸出錯誤
+                }
+            }
+            
+            // 寫入到日誌文件
+            try
+            {
+                File.AppendAllText(LogFilePath, logMessage + Environment.NewLine);
+            }
+            catch
+            {
+                // 忽略日誌寫入錯誤
+            }
+#endif
+        }
+
+        /// <summary>
+        /// 記錄成就設置操作
+        /// </summary>
+        public static void LogAchievementSet(string achievementId, bool achieved, bool isDebugMode)
+        {
+            if (isDebugMode)
+            {
+                LogDebug($"[MOCK] SetAchievement: {achievementId} = {achieved}");
+            }
+            else
+            {
+                LogDebug($"[REAL] SetAchievement: {achievementId} = {achieved}");
+            }
+        }
+
+        /// <summary>
+        /// 記錄統計設置操作
+        /// </summary>
+        public static void LogStatSet(string statId, object value, bool isDebugMode)
+        {
+            if (isDebugMode)
+            {
+                LogDebug($"[MOCK] SetStat: {statId} = {value}");
+            }
+            else
+            {
+                LogDebug($"[REAL] SetStat: {statId} = {value}");
+            }
+        }
+
+        /// <summary>
+        /// 記錄存儲操作
+        /// </summary>
+        public static void LogStoreStats(bool isDebugMode)
+        {
+            if (isDebugMode)
+            {
+                LogDebug("[MOCK] StoreStats: Changes would be committed to Steam (but not in debug mode)");
+            }
+            else
+            {
+                LogDebug("[REAL] StoreStats: Committing changes to Steam");
+            }
+        }
+
+        /// <summary>
+        /// 記錄重置操作
+        /// </summary>
+        public static void LogResetAllStats(bool achievementsToo, bool isDebugMode)
+        {
+            if (isDebugMode)
+            {
+                LogDebug($"[MOCK] ResetAllStats: achievements={achievementsToo} (would reset but not in debug mode)");
+            }
+            else
+            {
+                LogDebug($"[REAL] ResetAllStats: achievements={achievementsToo}");
+            }
+        }
+
+        /// <summary>
+        /// 清除日誌文件
+        /// </summary>
+        public static void ClearLog()
+        {
+#if DEBUG
+            try
+            {
+                if (File.Exists(LogFilePath))
+                {
+                    File.WriteAllText(LogFilePath, string.Empty);
+                }
+            }
+            catch
+            {
+                // 忽略清除錯誤
+            }
+#endif
+        }
+
+        /// <summary>
+        /// 檢查是否為 Debug 模式
+        /// </summary>
+        public static bool IsDebugMode
+        {
+            get
+            {
+#if DEBUG
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+    }
+}

--- a/MyOwnGames/Services/GameDataService.cs
+++ b/MyOwnGames/Services/GameDataService.cs
@@ -40,7 +40,7 @@ namespace MyOwnGames.Services
                 );
 
                 await Task.Run(() => root.Save(_xmlFilePath));
-                System.Diagnostics.Debug.WriteLine($"Saved {games.Count} games to {_xmlFilePath}");
+                DebugLogger.LogDebug($"Saved {games.Count} games to {_xmlFilePath}");
             }
             catch (Exception ex)
             {
@@ -67,12 +67,12 @@ namespace MyOwnGames.Services
                     })
                     .ToList() ?? new List<SteamGame>();
 
-                System.Diagnostics.Debug.WriteLine($"Loaded {games.Count} games from {_xmlFilePath}");
+                DebugLogger.LogDebug($"Loaded {games.Count} games from {_xmlFilePath}");
                 return games;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error loading games from XML: {ex.Message}");
+                DebugLogger.LogDebug($"Error loading games from XML: {ex.Message}");
                 return new List<SteamGame>();
             }
         }
@@ -99,7 +99,7 @@ namespace MyOwnGames.Services
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error getting export info: {ex.Message}");
+                DebugLogger.LogDebug($"Error getting export info: {ex.Message}");
                 return null;
             }
         }

--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -83,21 +83,21 @@ namespace MyOwnGames.Services
                             {
                                 // Ensure thread-safe file write
                                 await Task.Run(() => File.WriteAllBytes(filePath, content));
-                                System.Diagnostics.Debug.WriteLine($"Downloaded game image: {url} -> {filePath}");
+                                DebugLogger.LogDebug($"Downloaded game image: {url} -> {filePath}");
                                 return;
                             }
                         }
                     }
                     catch (Exception ex)
                     {
-                        System.Diagnostics.Debug.WriteLine($"Failed to download from {url}: {ex.Message}");
+                        DebugLogger.LogDebug($"Failed to download from {url}: {ex.Message}");
                         continue;
                     }
                 }
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error downloading game image for {appId}: {ex.Message}");
+                DebugLogger.LogDebug($"Error downloading game image for {appId}: {ex.Message}");
             }
         }
 
@@ -114,7 +114,7 @@ namespace MyOwnGames.Services
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error clearing image cache: {ex.Message}");
+                DebugLogger.LogDebug($"Error clearing image cache: {ex.Message}");
             }
         }
 

--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Globalization;
 using System.Threading;
+using MyOwnGames.Services;
 
 namespace MyOwnGames
 {
@@ -122,7 +123,7 @@ namespace MyOwnGames
             catch (Exception ex)
             {
                 // Log error and fall back to English name
-                System.Diagnostics.Debug.WriteLine($"Error getting localized name for {appId}: {ex.Message}");
+                DebugLogger.LogDebug($"Error getting localized name for {appId}: {ex.Message}");
             }
 
             return englishName; // Return English name as fallback


### PR DESCRIPTION
## Summary
- add DebugLogger to MyOwnGames with its own log directory
- replace System.Diagnostics.Debug.WriteLine with DebugLogger.LogDebug across MyOwnGames

## Testing
- `dotnet test AnSAM.sln` *(fails: NETSDK1100 to build Windows-targeting project on this OS)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a34af3808330b60d6c8d1704a37e