### PR TITLE
Refactor game list building off UI thread

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -381,7 +381,7 @@ namespace AnSAM
             });
         }
 
-        private Task<(List<GameItem> allGames, List<GameItem> filteredGames)> BuildGameListAsync(IEnumerable<SteamApp> apps, string? keyword)
+        private Task<(List<GameItem> allGames, List<GameItem> filteredGames)> BuildGameListAsync(IEnumerable<SteamAppData> apps, string? keyword)
         {
             return Task.Run(() =>
             {


### PR DESCRIPTION
## Summary
- build and sort game list on a background thread
- update UI with DispatcherQueue once game list is ready
- start refresh after activation without blocking window rendering

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a4324c2c833096aef7672f507263