### PR TITLE
Align achievement header columns with item layout

### DIFF
--- a/RunGame/MainWindow.xaml
+++ b/RunGame/MainWindow.xaml
@@ -50,14 +50,14 @@
                               SelectionMode="Extended"
                               Margin="10,0,10,10">
                         <ListView.Resources>
-                            <x:Double x:Key="AchievedColumnWidth">60</x:Double>
-                            <x:Double x:Key="IconColumnWidth">60</x:Double>
-                            <x:Double x:Key="IdColumnWidth">220</x:Double>
-                            <x:Double x:Key="NameColumnWidth">250</x:Double>
-                            <x:Double x:Key="DescriptionColumnWidth">300</x:Double>
-                            <x:Double x:Key="UnlockTimeColumnWidth">180</x:Double>
-                            <x:Double x:Key="ScheduledTimeColumnWidth">180</x:Double>
-                            <x:Double x:Key="PermissionColumnWidth">80</x:Double>
+                            <x:String x:Key="AchievedColumnWidth">60</x:String>
+                            <x:String x:Key="IconColumnWidth">60</x:String>
+                            <x:String x:Key="IdColumnWidth">220</x:String>
+                            <x:String x:Key="NameColumnWidth">250</x:String>
+                            <x:String x:Key="DescriptionColumnWidth">300</x:String>
+                            <x:String x:Key="UnlockTimeColumnWidth">180</x:String>
+                            <x:String x:Key="ScheduledTimeColumnWidth">180</x:String>
+                            <x:String x:Key="PermissionColumnWidth">80</x:String>
                         </ListView.Resources>
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">


### PR DESCRIPTION
## Summary
- synchronize achievement list header with row widths using shared width resources

## Testing
- `dotnet build RunGame/RunGame.csproj -c Debug -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`
- `dotnet run --project RunGame/RunGame.csproj -c Debug -p:EnableWindowsTargeting=true -- 597180` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6abe86aec83308ff690a0973cec3b