### PR TITLE
Expose icon download progress and update status UI

### DIFF
--- a/AnSAM.Tests/IconCacheTests.cs
+++ b/AnSAM.Tests/IconCacheTests.cs
@@ -37,7 +37,7 @@ public class IconCacheTests
 }
 
     [Fact]
-    public async Task ProgressReportsDownloadsOnly()
+    public async Task ProgressCountsCachedIcons()
     {
         IconCache.ResetProgress();
         var events = new List<(int completed, int total)>();
@@ -92,6 +92,6 @@ public class IconCacheTests
             IconCache.ProgressChanged -= Handler;
         }
 
-        Assert.Equal(new (int completed, int total)[] { (0, 1), (1, 1) }, events.ToArray());
+        Assert.Equal(new (int completed, int total)[] { (1, 1), (1, 2), (2, 2) }, events.ToArray());
     }
 }

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -350,6 +350,7 @@ namespace AnSAM
             }
 
             StatusText.Text = "Refresh";
+            StatusProgress.IsIndeterminate = false;
             StatusProgress.Value = 0;
             StatusExtra.Text = "0%";
 
@@ -569,7 +570,7 @@ namespace AnSAM
                     StatusExtra.Text = $"{completed}/{total}";
                     StatusText.Text = "Downloading icons…";
                 }
-                else if (total > 0)
+                else if (total > 0 && _allGames.Count > 0)
                 {
                     StatusText.Text = $"Loaded {_allGames.Count} games";
                     StatusProgress.Value = 0;

--- a/AnSAM/Services/IconCache.cs
+++ b/AnSAM/Services/IconCache.cs
@@ -91,6 +91,9 @@ namespace AnSAM.Services
 #if DEBUG
                         DebugLogger.LogDebug($"Using cached icon for {id} at {path}");
 #endif
+                        Interlocked.Increment(ref _totalRequests);
+                        Interlocked.Increment(ref _completed);
+                        ReportProgress();
                         return Task.FromResult(new IconPathResult(path, false));
                     }
 


### PR DESCRIPTION
## Summary
- expose icon download counters via `IconCache.GetProgress`
- show icon download progress during refresh and reset when downloads complete

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`
- `dotnet test` *(fails: NETSDK1100, Windows targeting on non-Windows OS)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ace2426c83309daaad7551e17c2d