### PR TITLE
feat: instant cached icon loading

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -652,6 +652,12 @@ namespace AnSAM
                                     app.Arguments,
                                     app.UriScheme);
 
+            if (IconCache.TryGetCachedPath(app.AppId) is string cached &&
+                Uri.TryCreate(cached, UriKind.Absolute, out var cachedUri))
+            {
+                item.CoverPath = cachedUri;
+            }
+
             if (app.CoverUrl != null)
             {
 #if DEBUG

--- a/AnSAM/Services/IconCache.cs
+++ b/AnSAM/Services/IconCache.cs
@@ -66,6 +66,35 @@ namespace AnSAM.Services
         }
 
         /// <summary>
+        /// Attempts to find a cached icon path for the given application id.
+        /// </summary>
+        /// <param name="id">Steam application identifier used to name the file.</param>
+        /// <returns>The cached file path if present and valid; otherwise <c>null</c>.</returns>
+        public static string? TryGetCachedPath(int id)
+        {
+            var basePath = Path.Combine(CacheDir, id.ToString());
+
+            foreach (var candidateExt in new HashSet<string>(MimeToExtension.Values))
+            {
+                var path = basePath + candidateExt;
+                if (File.Exists(path))
+                {
+                    if (IsCacheValid(path))
+                    {
+#if DEBUG
+                        DebugLogger.LogDebug($"Using cached icon for {id} at {path}");
+#endif
+                        return path;
+                    }
+
+                    try { File.Delete(path); } catch { }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Returns a local file path for the provided cover URI, downloading it if necessary.
         /// </summary>
         /// <param name="id">Steam application identifier used to name the file.</param>


### PR DESCRIPTION
## Summary
- add IconCache.TryGetCachedPath helper to reuse valid cached icons
- load cached icons immediately in GameItem.FromSteamApp using the new helper

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a6b4e3859883308358c11545461de6