### PR TITLE
Fix variable shadowing causing CS0136 compile error

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -652,8 +652,8 @@ namespace AnSAM
                                     app.Arguments,
                                     app.UriScheme);
 
-            if (IconCache.TryGetCachedPath(app.AppId) is string cached &&
-                Uri.TryCreate(cached, UriKind.Absolute, out var cachedUri))
+            if (IconCache.TryGetCachedPath(app.AppId) is string cachedPath &&
+                Uri.TryCreate(cachedPath, UriKind.Absolute, out var cachedUri))
             {
                 item.CoverPath = cachedUri;
             }
@@ -664,10 +664,10 @@ namespace AnSAM
                 DebugLogger.LogDebug($"Queueing icon download for {app.AppId} from {app.CoverUrl}");
 #endif
                 var dispatcher = DispatcherQueue.GetForCurrentThread();
-                var cached = IconCache.TryGetCachedIconUri(app.AppId);
-                if (cached != null)
+                var cachedIconUri = IconCache.TryGetCachedIconUri(app.AppId);
+                if (cachedIconUri != null)
                 {
-                    item.CoverPath = cached;
+                    item.CoverPath = cachedIconUri;
                 }
 
                 _ = LoadIconAsync();


### PR DESCRIPTION
## Summary
- Rename cached variables in MainWindow to avoid shadowing outer scope names
- Use distinct `cachedPath` and `cachedIconUri` identifiers for clarity

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc91192483308a01c97455900849