### PR TITLE
Defer game icon lookup when building list

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -400,10 +400,7 @@ namespace AnSAM
                 var allGames = new List<GameItem>();
                 foreach (var app in apps)
                 {
-                    var withCover = _steamClient.Initialized
-                        ? app with { CoverUrl = GameImageUrlResolver.GetGameImageUrl(_steamClient, (uint)app.AppId, "english") }
-                        : app;
-                    allGames.Add(GameItem.FromSteamApp(withCover));
+                    allGames.Add(GameItem.FromSteamApp(app));
                 }
 
                 allGames.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary
- Build game list without resolving cover image URLs
- Let icon caching handle images later

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a6bf8e4ae083309d5eed9c7d32d825