### PR TITLE
Surface debug logs in MyOwnGames UI

### DIFF
--- a/MyOwnGames/Services/DebugLogger.cs
+++ b/MyOwnGames/Services/DebugLogger.cs
@@ -6,6 +6,7 @@ namespace MyOwnGames.Services
 {
     public static class DebugLogger
     {
+        public static event Action<string>? OnLog;
         private static readonly string LogFilePath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "MyOwnGames", "debug.log");
@@ -28,6 +29,8 @@ namespace MyOwnGames.Services
 #if DEBUG
             var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             var logMessage = $"[{timestamp}] DEBUG: {message}";
+
+            OnLog?.Invoke(logMessage);
             
             // 輸出到控制台
             try


### PR DESCRIPTION
## Summary
- broadcast log messages through new `DebugLogger.OnLog` event
- show per-action progress in MyOwnGames by appending log entries for save/load, game fetches, and image downloads

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a71cccdb3c83308a0d1aec139ebb7d