### PR TITLE
Log retrieval progress for games

### DIFF
--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -88,7 +88,10 @@ namespace MyOwnGames
                     };
                     
                     games.Add(steamGame);
-                    
+
+                    // Log retrieval progress
+                    DebugLogger.LogDebug($"Retrieving game {i + 1}/{total}: {steamGame.NameEn}");
+
                     // Update progress more smoothly
                     var gameProgress = 40 + (60.0 * (i + 1) / total);
                     progress?.Report(gameProgress);


### PR DESCRIPTION
## Summary
- add debug log output for each retrieved game to show progress like `1/100`

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a720eb3ed48330a94f7c77f6c43b49