### PR TITLE
feat: resume game retrieval

### DIFF
--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -43,7 +43,7 @@ namespace MyOwnGames
             });
         }
 
-        public async Task GetOwnedGamesAsync(string steamId64, string targetLanguage = "tchinese", Func<SteamGame, Task>? onGameRetrieved = null, IProgress<double>? progress = null)
+        public async Task<int> GetOwnedGamesAsync(string steamId64, string targetLanguage = "tchinese", Func<SteamGame, Task>? onGameRetrieved = null, IProgress<double>? progress = null, ISet<int>? existingAppIds = null)
         {
             try
             {
@@ -56,7 +56,7 @@ namespace MyOwnGames
 
                 if (ownedGamesData?.response?.games == null)
                 {
-                    return;
+                    return 0;
                 }
 
                 progress?.Report(30);
@@ -67,6 +67,13 @@ namespace MyOwnGames
                 for (int i = 0; i < total; i++)
                 {
                     var game = ownedGamesData.response.games[i];
+
+                    if (existingAppIds != null && existingAppIds.Contains(game.appid))
+                    {
+                        var skipProgress = 30 + (70.0 * (i + 1) / total);
+                        progress?.Report(skipProgress);
+                        continue;
+                    }
 
                     // Get localized name if not English
                     string localizedName = game.name; // Default to English name from owned games API
@@ -96,6 +103,8 @@ namespace MyOwnGames
                     var gameProgress = 30 + (70.0 * (i + 1) / total);
                     progress?.Report(gameProgress);
                 }
+
+                return total;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- track previously saved game IDs and remaining expected total
- skip Steam API calls for already saved games
- update UI workflow to load saved IDs and record remaining count

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d3f0f7f483308de779f38f32fa69