### PR TITLE
Mask Steam credential input using PasswordBox

### DIFF
--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -48,9 +48,11 @@
                 <AppBarElementContainer>
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <TextBlock Text="Steam API Key" VerticalAlignment="Center"/>
-                        <TextBox x:Name="ApiKeyBox"
-                                 Width="340"
-                                 PlaceholderText="Your Steam Web API Key"/>
+                        <PasswordBox x:Name="ApiKeyBox"
+                                     Width="340"
+                                     PasswordChar="*"
+                                     PlaceholderText="Your Steam Web API Key"
+                                     IsPasswordRevealButtonEnabled="True"/>
                     </StackPanel>
                 </AppBarElementContainer>
 
@@ -58,9 +60,12 @@
                 <AppBarElementContainer>
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <TextBlock Text="SteamID_64" VerticalAlignment="Center"/>
-                        <TextBox x:Name="SteamIdBox"
-                                 Width="260"
-                                 PlaceholderText="7656119xxxxxxxxxx"/>
+                        <PasswordBox x:Name="SteamIdBox"
+                                     Width="260"
+                                     PasswordChar="*"
+                                     PlaceholderText="7656119xxxxxxxxxx"
+                                     IsPasswordRevealButtonEnabled="True"
+                                     InputScope="Number"/>
                     </StackPanel>
                 </AppBarElementContainer>
 

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -136,7 +136,7 @@ namespace MyOwnGames
             {
                 AppendLog("Loading saved games...");
                 StatusText = "Loading saved games...";
-                var enteredId = SteamIdBox.Text?.Trim() ?? string.Empty;
+                var enteredId = SteamIdBox.Password?.Trim() ?? string.Empty;
                 await EnsureSteamIdHashConsistencyAsync(enteredId);
                 var savedGames = await _dataService.LoadGamesFromXmlAsync();
                 
@@ -223,8 +223,8 @@ namespace MyOwnGames
 
         private async void GetGamesButton_Click(object sender, RoutedEventArgs e)
         {
-            var apiKey = ApiKeyBox.Text?.Trim();
-            var steamId64 = SteamIdBox.Text?.Trim();
+            var apiKey = ApiKeyBox.Password?.Trim();
+            var steamId64 = SteamIdBox.Password?.Trim();
 
             if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(steamId64))
             {


### PR DESCRIPTION
## Summary
- Protect sensitive Steam API and ID fields with PasswordBox controls that support reveal and numeric input
- Update code-behind to read values from Password properties

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8215bd5408330a8dbbacf2ffbe84a