### PR TITLE
Use LocalApplicationData cache directory for game data

### DIFF
--- a/MyOwnGames/Services/GameDataService.cs
+++ b/MyOwnGames/Services/GameDataService.cs
@@ -15,8 +15,8 @@ namespace MyOwnGames.Services
 
         public GameDataService()
         {
-            var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var appDataPath = Path.Combine(documentsPath, "MyOwnGames");
+            var basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var appDataPath = Path.Combine(basePath, "AchievoLab", "cache");
             Directory.CreateDirectory(appDataPath);
             _xmlFilePath = Path.Combine(appDataPath, "steam_games.xml");
         }


### PR DESCRIPTION
## Summary
- Use the LocalApplicationData folder under `AchievoLab/cache` for storing game XML data.

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a82c543310833084d9932f9660f39b