### PR TITLE
Use OneWay binding for game icons

### DIFF
--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -158,7 +158,7 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind AppId}"/>
 
                         <Grid Grid.Column="1" Width="40" Height="40">
-                            <Image Source="{x:Bind IconUri}" Stretch="Uniform"/>
+                            <Image Source="{x:Bind IconUri, Mode=OneWay}" Stretch="Uniform"/>
                         </Grid>
 
                         <TextBlock Grid.Column="2"


### PR DESCRIPTION
## Summary
- bind game icon image source with `Mode=OneWay` so freshly downloaded icons show up right away

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet run --project MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exited with code 126)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` *(fails: HttpRequestException 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a86da38fa88330890e7ae30944f498