### PR TITLE
Validate Steam credentials before fetching games

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="../AnSAM/Services/DebugLogger.cs" Link="DebugLogger.cs" />
     <Compile Include="../AnSAM/SteamAppData.cs" Link="SteamAppData.cs" />
     <Compile Include="../AnSAM/Steam/ISteamClient.cs" Link="ISteamClient.cs" />
+    <Compile Include="../MyOwnGames/InputValidator.cs" Link="InputValidator.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/AnSAM.Tests/InputValidatorTests.cs
+++ b/AnSAM.Tests/InputValidatorTests.cs
@@ -1,0 +1,37 @@
+using MyOwnGames;
+using Xunit;
+
+namespace AnSAM.Tests
+{
+    public class InputValidatorTests
+    {
+        [Theory]
+        [InlineData("0123456789ABCDEF0123456789ABCDE")] // 31 chars
+        [InlineData("0123456789ABCDEFG0123456789ABCDE0")] // non-hex
+        public void IsValidApiKey_Invalid_ReturnsFalse(string key)
+        {
+            Assert.False(InputValidator.IsValidApiKey(key));
+        }
+
+        [Fact]
+        public void IsValidApiKey_Valid_ReturnsTrue()
+        {
+            Assert.True(InputValidator.IsValidApiKey("0123456789ABCDEF0123456789ABCDEF"));
+        }
+
+        [Theory]
+        [InlineData("7656119801234567")] // 16 digits
+        [InlineData("76561298012345678")] // wrong prefix
+        [InlineData("7656119A01234567B")] // non-digit
+        public void IsValidSteamId64_Invalid_ReturnsFalse(string id)
+        {
+            Assert.False(InputValidator.IsValidSteamId64(id));
+        }
+
+        [Fact]
+        public void IsValidSteamId64_Valid_ReturnsTrue()
+        {
+            Assert.True(InputValidator.IsValidSteamId64("76561198012345678"));
+        }
+    }
+}

--- a/MyOwnGames/InputValidator.cs
+++ b/MyOwnGames/InputValidator.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+namespace MyOwnGames
+{
+    public static class InputValidator
+    {
+        private static readonly Regex ApiKeyRegex = new("^[0-9A-Fa-f]{32}$", RegexOptions.Compiled);
+        private static readonly Regex SteamId64Regex = new("^7656119\\d{10}$", RegexOptions.Compiled);
+
+        public static bool IsValidApiKey(string? apiKey)
+            => apiKey is not null && ApiKeyRegex.IsMatch(apiKey);
+
+        public static bool IsValidSteamId64(string? steamId64)
+            => steamId64 is not null && SteamId64Regex.IsMatch(steamId64);
+    }
+}

--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -52,7 +52,8 @@
                                      Width="340"
                                      PasswordChar="*"
                                      PlaceholderText="Your Steam Web API Key"
-                                     IsPasswordRevealButtonEnabled="True"/>
+                                     IsPasswordRevealButtonEnabled="True"
+                                     PasswordChanged="InputFields_PasswordChanged"/>
                     </StackPanel>
                 </AppBarElementContainer>
 
@@ -65,7 +66,8 @@
                                      PasswordChar="*"
                                      PlaceholderText="7656119xxxxxxxxxx"
                                      IsPasswordRevealButtonEnabled="True"
-                                     InputScope="Number"/>
+                                     InputScope="Number"
+                                     PasswordChanged="InputFields_PasswordChanged"/>
                     </StackPanel>
                 </AppBarElementContainer>
 
@@ -114,7 +116,8 @@
                 <AppBarButton x:Name="GetGamesButton"
                                    Icon="Download"
                                    Label="Get Game list"
-                                   Click="GetGamesButton_Click"/>
+                                   Click="GetGamesButton_Click"
+                                   IsEnabled="False"/>
             </CommandBar.PrimaryCommands>
         </CommandBar>
 

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -183,9 +183,11 @@ namespace MyOwnGames
 
             // Load saved games on startup
             _ = LoadSavedGamesAsync();
-            
+
             // Clean up old failed download records on startup
             _ = CleanupOldFailedRecordsAsync();
+
+            UpdateGetGamesButtonState();
         }
 
         private void OnImageDownloadCompleted(int appId, string? imagePath)
@@ -362,9 +364,15 @@ namespace MyOwnGames
             var apiKey = ApiKeyBox.Password?.Trim();
             var steamId64 = SteamIdBox.Password?.Trim();
 
-            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(steamId64))
+            if (!InputValidator.IsValidApiKey(apiKey))
             {
-                StatusText = "Please enter Steam API Key and SteamID_64.";
+                StatusText = "Invalid Steam API Key. It must be 32 hexadecimal characters.";
+                return;
+            }
+
+            if (!InputValidator.IsValidSteamId64(steamId64))
+            {
+                StatusText = "Invalid SteamID64. It must be a 17-digit number starting with 7656119.";
                 return;
             }
 
@@ -465,6 +473,18 @@ namespace MyOwnGames
                 ProgressValue = 100;
                 AppendLog("Finished retrieving games.");
             }
+        }
+
+        private void InputFields_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            UpdateGetGamesButtonState();
+        }
+
+        private void UpdateGetGamesButtonState()
+        {
+            var apiKey = ApiKeyBox.Password?.Trim();
+            var steamId64 = SteamIdBox.Password?.Trim();
+            GetGamesButton.IsEnabled = InputValidator.IsValidApiKey(apiKey) && InputValidator.IsValidSteamId64(steamId64);
         }
 
         private void KeywordBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)


### PR DESCRIPTION
## Summary
- validate Steam API key and SteamID64 formats before retrieving games
- disable "Get Game list" button until inputs are valid
- add reusable `InputValidator` with unit tests

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` *(fails: HttpRequestException 403 in IconCacheTests)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj --filter InputValidatorTests`


------
https://chatgpt.com/codex/tasks/task_e_68a8735535108330bf0fedc86e93ff70