### PR TITLE
Add Steam credential validation and async throttling

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -12,6 +12,8 @@
     <Compile Include="../AnSAM/SteamAppData.cs" Link="SteamAppData.cs" />
     <Compile Include="../AnSAM/Steam/ISteamClient.cs" Link="ISteamClient.cs" />
     <Compile Include="../MyOwnGames/InputValidator.cs" Link="InputValidator.cs" />
+    <Compile Include="../MyOwnGames/SteamApiService.cs" Link="SteamApiService.cs" />
+    <Compile Include="../MyOwnGames/Services/DebugLogger.cs" Link="MyOwnGames.DebugLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/AnSAM.Tests/SteamApiServiceTests.cs
+++ b/AnSAM.Tests/SteamApiServiceTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using MyOwnGames;
+using Xunit;
+
+namespace AnSAM.Tests
+{
+    public class SteamApiServiceTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("0123456789ABCDEFG0123456789ABCDEF")] // non-hex
+        [InlineData("0123456789ABCDEF0123456789ABCDE")] // too short
+        public void Constructor_InvalidApiKey_ThrowsArgumentException(string apiKey)
+        {
+            Assert.Throws<ArgumentException>(() => new SteamApiService(apiKey));
+        }
+
+        [Fact]
+        public async Task GetOwnedGamesAsync_InvalidSteamId_ThrowsArgumentException()
+        {
+            var service = new SteamApiService("0123456789ABCDEF0123456789ABCDEF");
+            await Assert.ThrowsAsync<ArgumentException>(() => service.GetOwnedGamesAsync("123"));
+        }
+    }
+}

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -460,6 +460,11 @@ namespace MyOwnGames
                 StatusText = $"Successfully processed {total} games ({selectedLanguage}). Current list: {GameItems.Count} games. Saved to {xmlPath}";
                 AppendLog($"Processing complete - Total: {total}, Current display: {GameItems.Count} games, saved to {xmlPath}");
             }
+            catch (ArgumentException ex)
+            {
+                StatusText = "Error: " + ex.Message;
+                AppendLog($"Validation error: {ex.Message}");
+            }
             catch (Exception ex)
             {
                 StatusText = "Error: " + ex.Message;


### PR DESCRIPTION
## Summary
- validate API key and SteamID in `SteamApiService` and throw `ArgumentException`
- replace blocking throttle with async `SemaphoreSlim`
- handle validation failures in UI and add tests

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` *(fails: Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a8758bc42c8330bb2bcb44fd8b81b0