### PR TITLE
Select default Steam language from OS culture

### DIFF
--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -76,8 +76,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <TextBlock Text="Language" VerticalAlignment="Center"/>
                         <ComboBox x:Name="LanguageComboBox"
-                                  Width="120"
-                                  SelectedIndex="1">
+                                  Width="120">
                             <ComboBoxItem Content="english"/>
                             <ComboBoxItem Content="tchinese"/>
                             <ComboBoxItem Content="japanese"/>

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -45,6 +45,8 @@ namespace MyOwnGames
         private bool _isShuttingDown;
         private CancellationTokenSource? _cancellationTokenSource;
 
+        private readonly string _defaultLanguage = GetDefaultLanguage();
+
         private readonly AppWindow _appWindow;
 
         private string _statusText = "Ready.";
@@ -155,11 +157,33 @@ namespace MyOwnGames
                 // Ignore all exceptions during shutdown
             }
         }
+
+        private static string GetDefaultLanguage()
+        {
+            var culture = CultureInfo.CurrentCulture.Name;
+            if (culture.Equals("zh-TW", StringComparison.OrdinalIgnoreCase))
+                return "tchinese";
+            if (culture.StartsWith("ja", StringComparison.OrdinalIgnoreCase))
+                return "japanese";
+            if (culture.StartsWith("ko", StringComparison.OrdinalIgnoreCase))
+                return "korean";
+            if (culture.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+                return "english";
+            return "english";
+        }
         public MainWindow()
         {
             InitializeComponent();
             this.ExtendsContentIntoTitleBar = true;
             this.AppWindow.Title = "My Own Steam Games";
+
+            var defaultItem = LanguageComboBox.Items
+                .OfType<ComboBoxItem>()
+                .FirstOrDefault(i => string.Equals(i.Content?.ToString(), _defaultLanguage, StringComparison.OrdinalIgnoreCase));
+            if (defaultItem != null)
+            {
+                LanguageComboBox.SelectedItem = defaultItem;
+            }
 
             _logHandler = message => DispatcherQueue.TryEnqueue(() => AppendLog(message));
             DebugLogger.OnLog += _logHandler;
@@ -396,10 +420,10 @@ namespace MyOwnGames
                 });
 
                 // Get selected language from ComboBox
-                var selectedLanguage = "tchinese"; // Default
+                var selectedLanguage = _defaultLanguage;
                 if (LanguageComboBox.SelectedItem is ComboBoxItem selectedItem)
                 {
-                    selectedLanguage = selectedItem.Content?.ToString() ?? "tchinese";
+                    selectedLanguage = selectedItem.Content?.ToString() ?? _defaultLanguage;
                 }
 
                 // Load existing app IDs to avoid re-fetching


### PR DESCRIPTION
## Summary
- Remove preselected language from combo box
- Map OS culture to Steam language codes and preselect the match
- Use culture-derived default for API calls

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: HttpRequestException - Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a883b2f21483309cab4e2d8426de0f