### PR TITLE
Default to English for Steam game exports

### DIFF
--- a/MyOwnGames/Services/GameDataService.cs
+++ b/MyOwnGames/Services/GameDataService.cs
@@ -21,7 +21,7 @@ namespace MyOwnGames.Services
             _xmlFilePath = Path.Combine(appDataPath, "steam_games.xml");
         }
 
-        public async Task SaveGamesToXmlAsync(List<SteamGame> games, string steamId64, string apiKey, string language = "tchinese")
+        public async Task SaveGamesToXmlAsync(List<SteamGame> games, string steamId64, string apiKey, string language = "english")
         {
             try
             {
@@ -51,7 +51,7 @@ namespace MyOwnGames.Services
             }
         }
 
-        public async Task AppendGameAsync(SteamGame game, string steamId64, string apiKey, string language = "tchinese")
+        public async Task AppendGameAsync(SteamGame game, string steamId64, string apiKey, string language = "english")
         {
             try
             {
@@ -225,7 +225,7 @@ namespace MyOwnGames.Services
                     SteamIdHash = root.Attribute("SteamIdHash")?.Value ?? "",
                     ExportDate = DateTime.Parse(root.Attribute("ExportDate")?.Value ?? DateTime.MinValue.ToString()),
                     TotalGames = int.Parse(root.Attribute("TotalGames")?.Value ?? "0"),
-                    Language = root.Attribute("Language")?.Value ?? "tchinese",
+                    Language = root.Attribute("Language")?.Value ?? "english",
                     ApiKeyHash = root.Attribute("ApiKeyHash")?.Value ?? ""
                 };
             }
@@ -276,7 +276,7 @@ namespace MyOwnGames.Services
         public string SteamIdHash { get; set; } = "";
         public DateTime ExportDate { get; set; }
         public int TotalGames { get; set; }
-        public string Language { get; set; } = "tchinese";
+        public string Language { get; set; } = "english";
         public string ApiKeyHash { get; set; } = "";
     }
 }

--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -44,7 +44,7 @@ namespace MyOwnGames
                 throw new ArgumentException("Invalid SteamID64. It must be a 17-digit number starting with 7656119.", nameof(steamId64));
         }
 
-        public async Task<int> GetOwnedGamesAsync(string steamId64, string targetLanguage = "tchinese", Func<SteamGame, Task>? onGameRetrieved = null, IProgress<double>? progress = null, ISet<int>? existingAppIds = null)
+        public async Task<int> GetOwnedGamesAsync(string steamId64, string targetLanguage = "english", Func<SteamGame, Task>? onGameRetrieved = null, IProgress<double>? progress = null, ISet<int>? existingAppIds = null)
         {
             ValidateCredentials(_apiKey, steamId64);
             try


### PR DESCRIPTION
## Summary
- Default Steam API calls and XML exports to use English language
- Preserve selected language by reading from UI and forwarding to services

## Testing
- `dotnet test` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a885c6d3288330a3e763212d04cba6