### PR TITLE
Add game filtering with full list preservation

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -529,7 +529,7 @@ namespace MyOwnGames
 
         private void KeywordBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
-            if (args.Reason == AutoSuggestBoxTextChangeReason.UserInput)
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
             {
                 FilterGameItems(sender.Text?.Trim());
             }


### PR DESCRIPTION
## Summary
- keep an unfiltered copy of games to restore after searches
- add case-insensitive keyword filtering across names and app ids
- update image and load routines to use the full list

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: System.Net.Http.HttpRequestException: Response status code does not indicate success: 403 (Forbidden).)*

------
https://chatgpt.com/codex/tasks/task_e_68a900fba0408330bae13067a75ec6c2