### PR TITLE
Add keyboard scrolling support for GamesGridView

### DIFF
--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -127,6 +127,7 @@
                   ItemsSource="{Binding GameItems}"
                   SelectionMode="None"
                   IsItemClickEnabled="False"
+                  IsTabStop="False"
                   DoubleTapped="GamesGridView_DoubleTapped"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ScrollViewer.HorizontalScrollMode="Disabled">


### PR DESCRIPTION
## Summary
- handle PageUp/PageDown/Up/Down at the window level to scroll the games list
- locate the GamesGridView ScrollViewer with a reusable FindScrollViewer helper
- prevent focus on the games grid to keep keyboard navigation from selecting items

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a946f4af50833081f2332b1a7a2446