### PR TITLE
Assert non-null API inputs

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -437,7 +437,7 @@ namespace MyOwnGames
                 return;
             }
 
-            await EnsureSteamIdHashConsistencyAsync(steamId64);
+            await EnsureSteamIdHashConsistencyAsync(steamId64!);
 
             string? xmlPath = null;
             
@@ -474,8 +474,8 @@ namespace MyOwnGames
                 var existingGamesData = await _dataService.LoadGamesWithLanguagesAsync();
                 
                 // Use real Steam API service with selected language
-                _steamService = new SteamApiService(apiKey);
-                var total = await _steamService.GetOwnedGamesAsync(steamId64, selectedLanguage, async game =>
+                _steamService = new SteamApiService(apiKey!);
+                var total = await _steamService.GetOwnedGamesAsync(steamId64!, selectedLanguage, async game =>
                 {
                     // Check if this game has data for the current language
                     var existingGameData = existingGamesData.FirstOrDefault(g => g.AppId == game.AppId);


### PR DESCRIPTION
## Summary
- use null-forgiving operator for validated Steam ID before hashing and Steam API usage
- ensure null-forgiving operator used for API key and Steam ID when constructing Steam API service and fetching games

## Testing
- `dotnet build AnSAM.sln -p:EnableWindowsTargeting=true` *(fails: /root/.nuget/packages/microsoft.windowsappsdk/.../XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a9489a795883308a62de8f26d9d297