### PR TITLE
Fix nullability warnings for game append

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -523,7 +523,7 @@ namespace MyOwnGames
                     }
 
                     // Always save/update game data in XML for current language
-                    await _dataService.AppendGameAsync(game, steamId64, apiKey, selectedLanguage);
+                    await _dataService.AppendGameAsync(game, steamId64!, apiKey!, selectedLanguage);
                 }, progress, null); // Pass null to process ALL games, not just missing ones
 
                 xmlPath = _dataService.GetXmlFilePath();


### PR DESCRIPTION
## Summary
- ensure `steamId64` and `apiKey` are treated as non-null when appending game data

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` (fails: HttpRequestException 403)
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` (fails: XamlCompiler.exe exec format error)


------
https://chatgpt.com/codex/tasks/task_e_68a94b15006483309102e9158548368e