### PR TITLE
Disable self-contained release builds

### DIFF
--- a/AnSAM/AnSAM.csproj
+++ b/AnSAM/AnSAM.csproj
@@ -85,6 +85,8 @@
     <OutputPath>..\output\Release\$(Platform)\$(TargetFramework)\AnSAM\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SelfContained>false</SelfContained>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" />

--- a/MyOwnGames/MyOwnGames.csproj
+++ b/MyOwnGames/MyOwnGames.csproj
@@ -92,6 +92,8 @@
     <OutputPath>..\output\Release\$(Platform)\$(TargetFramework)\MyOwnGames\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SelfContained>false</SelfContained>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ A 64-bit Steam achievement management GUI built with WinUI 3 and .NET 8, compati
 - Fetches, caches, and reuses cover icons for games.
 - Allows launching games directly from the GUI via right-click context menu.
 - Retrieves your owned game list and localized game titles (if available) through the Steam Web API.
+ 
+## Prerequisites
+These apps use framework-dependent deployments. Ensure the target machine has the following runtimes installed:
+
+- [.NET 8 Desktop Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [Windows App SDK 1.7 Runtime](https://learn.microsoft.com/windows/apps/windows-app-sdk/)
+
+You can install them via [winget](https://learn.microsoft.com/windows/package-manager/winget/):
+
+```powershell
+winget install Microsoft.DotNet.DesktopRuntime.8 Microsoft.WindowsAppSDK.1.7
+```
 
 ## Program List
 1. **./AnASM/AnASM.exe**  

--- a/RunGame/RunGame.csproj
+++ b/RunGame/RunGame.csproj
@@ -69,6 +69,8 @@
     <OutputPath>..\output\Release\$(Platform)\$(TargetFramework)\RunGame\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SelfContained>false</SelfContained>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">


### PR DESCRIPTION
## Summary
- make release builds framework-dependent for AnSAM, MyOwnGames, and RunGame
- document .NET and Windows App SDK runtime prerequisites

## Testing
- `dotnet build AnSAM.sln -c Release -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d5acd348330ab0fd46ecaec281c