### PR TITLE
Disable ReadyToRun for Release builds

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -4,6 +4,9 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="../AnSAM/Services/IconCache.cs" Link="IconCache.cs" />
     <Compile Include="../AnSAM/Services/GameCacheService.cs" Link="GameCacheService.cs" />

--- a/AnSAM/AnSAM.csproj
+++ b/AnSAM/AnSAM.csproj
@@ -57,7 +57,7 @@
   <!-- Publish Properties -->
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Release'">False</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>

--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -3,4 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
 </Project>

--- a/MyOwnGames/MyOwnGames.csproj
+++ b/MyOwnGames/MyOwnGames.csproj
@@ -69,7 +69,7 @@
   <!-- Publish Properties -->
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Release'">False</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>

--- a/RunGame/RunGame.csproj
+++ b/RunGame/RunGame.csproj
@@ -41,7 +41,7 @@
   <!-- Publish Properties -->
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Release'">False</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
## Summary
- Disable ReadyToRun compilation for Release configuration across all projects.

## Testing
- `dotnet build AnSAM.sln -c Release -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj -c Release` *(fails: HttpRequestException 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9542c51cc8330b4f8a86bd5c6f70a