### PR TITLE
Enable compressed single-file publish

### DIFF
--- a/AnSAM/AnSAM.csproj
+++ b/AnSAM/AnSAM.csproj
@@ -91,6 +91,8 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <SelfContained>false</SelfContained>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" />

--- a/MyOwnGames/MyOwnGames.csproj
+++ b/MyOwnGames/MyOwnGames.csproj
@@ -98,6 +98,8 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <SelfContained>false</SelfContained>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
 
 </Project>

--- a/RunGame/RunGame.csproj
+++ b/RunGame/RunGame.csproj
@@ -75,6 +75,8 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <SelfContained>false</SelfContained>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">


### PR DESCRIPTION
## Summary
- compress single-file executables in Release builds for AnSAM, RunGame, and MyOwnGames

## Testing
- `dotnet publish AnSAM/AnSAM.csproj -c Release -r win-x64 -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet publish RunGame/RunGame.csproj -c Release -r win-x64 -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet publish MyOwnGames/MyOwnGames.csproj -c Release -r win-x64 -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a956c95b4483308e4a3d6759f73329