### PR TITLE
Handle Chinese locale variants for Steam cover images

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="../AnSAM/Services/IconCache.cs" Link="IconCache.cs" />
     <Compile Include="../AnSAM/Services/GameCacheService.cs" Link="GameCacheService.cs" />
     <Compile Include="../AnSAM/Services/GameListService.cs" Link="GameListService.cs" />
+    <Compile Include="../AnSAM/Services/SteamLanguageResolver.cs" Link="SteamLanguageResolver.cs" />
     <Compile Include="../AnSAM/SteamAppData.cs" Link="SteamAppData.cs" />
     <Compile Include="../AnSAM/Steam/ISteamClient.cs" Link="ISteamClient.cs" />
     <Compile Include="../MyOwnGames/InputValidator.cs" Link="InputValidator.cs" />

--- a/AnSAM.Tests/SteamLanguageResolverTests.cs
+++ b/AnSAM.Tests/SteamLanguageResolverTests.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using AnSAM.Services;
+using Xunit;
+
+public class SteamLanguageResolverTests
+{
+    [Theory]
+    [InlineData("zh-TW", "tchinese")]
+    [InlineData("zh-HK", "tchinese")]
+    [InlineData("zh-CN", "schinese")]
+    [InlineData("zh", "tchinese")]
+    public void GetSteamLanguage_ReturnsExpectedLanguage(string cultureName, string expected)
+    {
+        var culture = new CultureInfo(cultureName);
+        var language = SteamLanguageResolver.GetSteamLanguage(culture);
+        Assert.Equal(expected, language);
+    }
+}

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -682,19 +682,7 @@ namespace AnSAM
                     return;
                 }
 
-                string language = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName switch
-                {
-                    "es" => "spanish",
-                    "fr" => "french",
-                    "de" => "german",
-                    "it" => "italian",
-                    "pt" => "portuguese",
-                    "ru" => "russian",
-                    "ja" => "japanese",
-                    "ko" => "korean",
-                    "zh" => "tchinese",
-                    _ => "english"
-                };
+                string language = SteamLanguageResolver.GetSteamLanguage(CultureInfo.CurrentUICulture);
 
                 var url = GameImageUrlResolver.GetGameImageUrl(client, (uint)ID, language);
 

--- a/AnSAM/Services/SteamLanguageResolver.cs
+++ b/AnSAM/Services/SteamLanguageResolver.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+
+namespace AnSAM.Services
+{
+    public static class SteamLanguageResolver
+    {
+        public static string GetSteamLanguage(CultureInfo culture)
+        {
+            return culture.Name switch
+            {
+                "zh-TW" or "zh-HK" => "tchinese",
+                "zh-CN" => "schinese",
+                var name when name.StartsWith("zh", StringComparison.OrdinalIgnoreCase) => "tchinese",
+                _ => culture.TwoLetterISOLanguageName switch
+                {
+                    "es" => "spanish",
+                    "fr" => "french",
+                    "de" => "german",
+                    "it" => "italian",
+                    "pt" => "portuguese",
+                    "ru" => "russian",
+                    "ja" => "japanese",
+                    "ko" => "korean",
+                    _ => "english"
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize Steam language mapping with proper Chinese locale handling
- resolve zh-CN to schinese and zh-HK/zh-TW/other zh variants to tchinese
- add tests covering Chinese locale mappings

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` *(fails: System.Net.Http.HttpRequestException: Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a95b9fe7d083309d273208f287a3fd