### PR TITLE
Expand Steam language mappings with tests

### DIFF
--- a/AnSAM.Tests/SteamLanguageResolverTests.cs
+++ b/AnSAM.Tests/SteamLanguageResolverTests.cs
@@ -5,14 +5,65 @@ using Xunit;
 public class SteamLanguageResolverTests
 {
     [Theory]
+    [InlineData("ar", "arabic")]
+    [InlineData("pt-BR", "brazilian")]
+    [InlineData("bg", "bulgarian")]
+    [InlineData("cs", "czech")]
+    [InlineData("da", "danish")]
+    [InlineData("nl", "dutch")]
+    [InlineData("fi", "finnish")]
+    [InlineData("fr", "french")]
+    [InlineData("de", "german")]
+    [InlineData("el", "greek")]
+    [InlineData("hu", "hungarian")]
+    [InlineData("id", "indonesian")]
+    [InlineData("it", "italian")]
+    [InlineData("ja", "japanese")]
+    [InlineData("ko", "koreana")]
+    [InlineData("es-419", "latam")]
+    [InlineData("no", "norwegian")]
+    [InlineData("pl", "polish")]
+    [InlineData("pt-PT", "portuguese")]
+    [InlineData("ro", "romanian")]
+    [InlineData("ru", "russian")]
+    [InlineData("zh-CN", "schinese")]
+    [InlineData("es", "spanish")]
+    [InlineData("sv", "swedish")]
+    [InlineData("th", "thai")]
+    [InlineData("tr", "turkish")]
+    [InlineData("uk", "ukrainian")]
+    [InlineData("vi", "vietnamese")]
     [InlineData("zh-TW", "tchinese")]
     [InlineData("zh-HK", "tchinese")]
-    [InlineData("zh-CN", "schinese")]
     [InlineData("zh", "tchinese")]
     public void GetSteamLanguage_ReturnsExpectedLanguage(string cultureName, string expected)
     {
         var culture = new CultureInfo(cultureName);
         var language = SteamLanguageResolver.GetSteamLanguage(culture);
         Assert.Equal(expected, language);
+    }
+
+    [Fact]
+    public void GetSteamLanguage_UnknownCulture_FallsBackToEnglish()
+    {
+        var culture = new CultureInfo("fa");
+        var language = SteamLanguageResolver.GetSteamLanguage(culture);
+        Assert.Equal("english", language);
+    }
+
+    [Fact]
+    public void GetSteamLanguage_UsesCurrentUICulture()
+    {
+        var original = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("es-419");
+            var language = SteamLanguageResolver.GetSteamLanguage();
+            Assert.Equal("latam", language);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = original;
+        }
     }
 }

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -682,7 +682,7 @@ namespace AnSAM
                     return;
                 }
 
-                string language = SteamLanguageResolver.GetSteamLanguage(CultureInfo.CurrentUICulture);
+                string language = SteamLanguageResolver.GetSteamLanguage();
 
                 var url = GameImageUrlResolver.GetGameImageUrl(client, (uint)ID, language);
 

--- a/AnSAM/Services/SteamLanguageResolver.cs
+++ b/AnSAM/Services/SteamLanguageResolver.cs
@@ -12,19 +12,40 @@ namespace AnSAM.Services
                 "zh-TW" or "zh-HK" => "tchinese",
                 "zh-CN" => "schinese",
                 var name when name.StartsWith("zh", StringComparison.OrdinalIgnoreCase) => "tchinese",
+                "pt-BR" => "brazilian",
+                var name when name.StartsWith("es", StringComparison.OrdinalIgnoreCase) && name != "es" && name != "es-ES" => "latam",
                 _ => culture.TwoLetterISOLanguageName switch
                 {
-                    "es" => "spanish",
+                    "ar" => "arabic",
+                    "bg" => "bulgarian",
+                    "cs" => "czech",
+                    "da" => "danish",
+                    "nl" => "dutch",
+                    "fi" => "finnish",
                     "fr" => "french",
                     "de" => "german",
+                    "el" => "greek",
+                    "hu" => "hungarian",
+                    "id" => "indonesian",
                     "it" => "italian",
-                    "pt" => "portuguese",
-                    "ru" => "russian",
                     "ja" => "japanese",
-                    "ko" => "korean",
+                    "ko" => "koreana",
+                    "nb" or "nn" or "no" => "norwegian",
+                    "pl" => "polish",
+                    "pt" => "portuguese",
+                    "ro" => "romanian",
+                    "ru" => "russian",
+                    "es" => "spanish",
+                    "sv" => "swedish",
+                    "th" => "thai",
+                    "tr" => "turkish",
+                    "uk" => "ukrainian",
+                    "vi" => "vietnamese",
                     _ => "english"
                 }
             };
         }
+
+        public static string GetSteamLanguage() => GetSteamLanguage(CultureInfo.CurrentUICulture);
     }
 }


### PR DESCRIPTION
## Summary
- map additional cultures to Steam language codes while preserving existing Chinese handling
- use resolver for OS language detection with english fallback
- add unit tests covering all mappings and fallback behavior

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj` *(fails: Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a95eaf4e908330a6cd57d540506567