### PR TITLE
feat: expose full language options

### DIFF
--- a/RunGame/MainWindow.xaml.cs
+++ b/RunGame/MainWindow.xaml.cs
@@ -233,18 +233,26 @@ namespace RunGame
 
         private void InitializeLanguageComboBox()
         {
-            var languages = new[] 
-            { 
-                "english", "spanish", "french", "german", "italian", "portuguese", 
-                "russian", "japanese", "korean", "schinese", "tchinese" 
-            };
-            
-            foreach (var lang in languages)
+            var languages = SteamLanguageResolver.SupportedLanguages.ToList();
+            var osLanguage = SteamLanguageResolver.GetSteamLanguage(CultureInfo.CurrentUICulture);
+
+            var orderedLanguages = new List<string> { osLanguage };
+            if (!string.Equals(osLanguage, "english", StringComparison.OrdinalIgnoreCase))
+            {
+                orderedLanguages.Add("english");
+            }
+
+            orderedLanguages.AddRange(
+                languages.Where(l => l != osLanguage && l != "english")
+                         .OrderBy(l => l));
+
+            foreach (var lang in orderedLanguages)
             {
                 LanguageComboBox.Items.Add(lang);
             }
-            
-            LanguageComboBox.SelectedItem = "english";
+
+            var selected = languages.Contains(osLanguage) ? osLanguage : "english";
+            LanguageComboBox.SelectedItem = selected;
         }
 
         private void InitializeColumnLayoutComboBox()
@@ -801,10 +809,44 @@ namespace RunGame
 
         private async void OnLanguageChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_gameStatsService != null)
+            if (_gameStatsService == null)
+                return;
+
+            string currentLanguage = LanguageComboBox.SelectedItem as string ?? "english";
+
+            LoadingRing.IsActive = true;
+
+            foreach (var achievement in _allAchievements)
             {
-                await LoadStatsAsync();
+                achievement.PropertyChanged -= OnAchievementPropertyChanged;
             }
+
+            if (!_gameStatsService.LoadUserGameStatsSchema(currentLanguage))
+            {
+                StatusLabel.Text = "Failed to load game schema";
+                LoadingRing.IsActive = false;
+                return;
+            }
+
+            _allAchievements = _gameStatsService.GetAchievements().ToList();
+
+            foreach (var achievement in _allAchievements)
+            {
+                if (_achievementCounters.TryGetValue(achievement.Id, out int counter))
+                {
+                    achievement.Counter = counter;
+                }
+                achievement.OriginalIsAchieved = achievement.IsAchieved;
+                achievement.PropertyChanged += OnAchievementPropertyChanged;
+            }
+
+            await LoadAchievements();
+            LoadStatistics();
+            UpdateScheduledTimesDisplay();
+            await LoadAchievementIconsAsync();
+            _achievementTimerService?.NotifyStatsReloaded();
+
+            LoadingRing.IsActive = false;
         }
 
         private void OnColumnLayoutChanged(object sender, SelectionChangedEventArgs e)

--- a/RunGame/Services/SteamLanguageResolver.cs
+++ b/RunGame/Services/SteamLanguageResolver.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace RunGame.Services
+{
+    public static class SteamLanguageResolver
+    {
+        private static string? _overrideLanguage;
+
+        public static readonly IReadOnlyList<string> SupportedLanguages = new[]
+        {
+            "arabic", "brazilian", "bulgarian", "czech", "danish", "dutch",
+            "english", "finnish", "french", "german", "greek", "hungarian",
+            "indonesian", "italian", "japanese", "koreana", "latam", "norwegian",
+            "polish", "portuguese", "romanian", "russian", "schinese", "spanish",
+            "swedish", "thai", "turkish", "ukrainian", "vietnamese", "tchinese"
+        };
+
+        public static string? OverrideLanguage
+        {
+            get => _overrideLanguage;
+            set => _overrideLanguage = string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        public static string GetSteamLanguage(CultureInfo culture)
+        {
+            return culture.Name switch
+            {
+                "zh-TW" or "zh-HK" => "tchinese",
+                "zh-CN" => "schinese",
+                var name when name.StartsWith("zh", StringComparison.OrdinalIgnoreCase) => "tchinese",
+                "pt-BR" => "brazilian",
+                var name when name.StartsWith("es", StringComparison.OrdinalIgnoreCase) && name != "es" && name != "es-ES" => "latam",
+                _ => culture.TwoLetterISOLanguageName switch
+                {
+                    "ar" => "arabic",
+                    "bg" => "bulgarian",
+                    "cs" => "czech",
+                    "da" => "danish",
+                    "nl" => "dutch",
+                    "fi" => "finnish",
+                    "fr" => "french",
+                    "de" => "german",
+                    "el" => "greek",
+                    "hu" => "hungarian",
+                    "id" => "indonesian",
+                    "it" => "italian",
+                    "ja" => "japanese",
+                    "ko" => "koreana",
+                    "nb" or "nn" or "no" => "norwegian",
+                    "pl" => "polish",
+                    "pt" => "portuguese",
+                    "ro" => "romanian",
+                    "ru" => "russian",
+                    "es" => "spanish",
+                    "sv" => "swedish",
+                    "th" => "thai",
+                    "tr" => "turkish",
+                    "uk" => "ukrainian",
+                    "vi" => "vietnamese",
+                    _ => "english"
+                }
+            };
+        }
+
+        public static string GetSteamLanguage()
+        {
+            if (!string.IsNullOrEmpty(OverrideLanguage))
+            {
+                return OverrideLanguage;
+            }
+
+            return GetSteamLanguage(CultureInfo.CurrentUICulture);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace language combobox static list with SteamLanguageResolver list and order by OS language
- detect and select OS language with English fallback
- reload schema and stats when the language selection changes

## Testing
- `dotnet test` *(fails: NETSDK1100: To build a project targeting Windows on this OS, set EnableWindowsTargeting to true)*

------
https://chatgpt.com/codex/tasks/task_e_68a9666adf4c833093d9fa775621eb01