### PR TITLE
Query Steam for game language

### DIFF
--- a/RunGame/Services/GameStatsService.cs
+++ b/RunGame/Services/GameStatsService.cs
@@ -342,7 +342,7 @@ namespace RunGame.Services
         
         public string GetCurrentGameLanguage()
         {
-            return _steamClient.GetCurrentGameLanguage() ?? "english";
+            return _steamClient.GetCurrentGameLanguage();
         }
 
         public List<AchievementInfo> GetAchievements()

--- a/RunGame/Steam/SteamGameClient.cs
+++ b/RunGame/Steam/SteamGameClient.cs
@@ -55,6 +55,7 @@ namespace RunGame.Steam
 
         // ISteamUtils delegates
         private readonly GetAppIdDelegate? _getAppId;
+        private readonly GetSteamUILanguageDelegate? _getSteamUILanguage;
         private readonly IntPtr _utils;
 
         private readonly List<Action<UserStatsReceived>> _userStatsCallbacks = new();
@@ -66,9 +67,27 @@ namespace RunGame.Steam
 
         public bool Initialized { get; }
         
-        public string? GetCurrentGameLanguage()
+        public string GetCurrentGameLanguage()
         {
             // Default to English if we can't determine the language
+            try
+            {
+                if (Initialized && _getSteamUILanguage != null && _utils != IntPtr.Zero)
+                {
+                    var ptr = _getSteamUILanguage(_utils);
+                    if (ptr != IntPtr.Zero)
+                    {
+                        var lang = Marshal.PtrToStringAnsi(ptr);
+                        if (!string.IsNullOrEmpty(lang))
+                            return lang;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugLogger.LogDebug($"Error getting Steam UI language: {ex.Message}");
+            }
+
             return "english";
         }
 
@@ -197,7 +216,9 @@ namespace RunGame.Steam
                                 {
                                     IntPtr utilsVTable = Marshal.ReadIntPtr(_utils);
                                     _getAppId = Marshal.GetDelegateForFunctionPointer<GetAppIdDelegate>(Marshal.ReadIntPtr(utilsVTable + IntPtr.Size * 9));
+                                    _getSteamUILanguage = Marshal.GetDelegateForFunctionPointer<GetSteamUILanguageDelegate>(Marshal.ReadIntPtr(utilsVTable + IntPtr.Size * 22));
                                     DebugLogger.LogDebug($"ISteamUtils005 GetAppId delegate initialized");
+                                    DebugLogger.LogDebug($"ISteamUtils005 GetSteamUILanguage delegate initialized");
                                 }
 
                                 // Check if we can get Steam ID to verify user is logged in
@@ -808,5 +829,8 @@ namespace RunGame.Steam
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         private delegate uint GetAppIdDelegate(IntPtr self);
+
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate IntPtr GetSteamUILanguageDelegate(IntPtr self);
     }
 }


### PR DESCRIPTION
## Summary
- query Steam's ISteamUtils for UI language with a fallback to English
- expose language from SteamGameClient and use in GameStatsService

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Response status code does not indicate success: 403 (Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68a9685d43a883308ecd2e894dd0ad93