### PR TITLE
Preserve historical timestamps when migrating image failures

### DIFF
--- a/AnSAM.Tests/ImageFailureTrackingServiceTests.cs
+++ b/AnSAM.Tests/ImageFailureTrackingServiceTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using CommonUtilities;
+using Xunit;
+
+public class ImageFailureTrackingServiceTests
+{
+    [Fact]
+    public void MigratedRecordsRetainLastFailedTimestamp()
+    {
+        var tracker = new ImageFailureTrackingService();
+        var xmlPath = tracker.GetXmlFilePath();
+        var dir = Path.GetDirectoryName(xmlPath)!;
+
+        var oldFile = Path.Combine(dir, "steam_games_failed.xml");
+
+        // Clean up before test
+        if (File.Exists(oldFile)) File.Delete(oldFile);
+        if (File.Exists(oldFile + ".migrated")) File.Delete(oldFile + ".migrated");
+
+        var appId = Random.Shared.Next(700001, 800000);
+        var lastFailed = DateTime.Now.AddDays(-3);
+        var lastFailedStr = lastFailed.ToString("yyyy-MM-dd HH:mm:ss");
+
+        var oldDoc = new XDocument(new XElement("FailedDownloads",
+            new XElement("Game",
+                new XAttribute("AppId", appId),
+                new XAttribute("GameName", "TestGame"),
+                new XAttribute("LastFailed", lastFailedStr))));
+        oldDoc.Save(oldFile);
+
+        tracker.MigrateOldFailedRecords();
+
+        var newDoc = XDocument.Load(xmlPath);
+        var migrated = newDoc.Root?.Elements("Game")
+            .FirstOrDefault(g => (int?)g.Attribute("AppId") == appId)?
+            .Elements("Language")
+            .FirstOrDefault(l => l.Attribute("Code")?.Value == "english")?
+            .Attribute("LastFailed")?.Value;
+
+        Assert.Equal(lastFailedStr, migrated);
+
+        // Cleanup
+        tracker.RemoveFailedRecord(appId, "english");
+        if (File.Exists(oldFile)) File.Delete(oldFile);
+        if (File.Exists(oldFile + ".migrated")) File.Delete(oldFile + ".migrated");
+    }
+}


### PR DESCRIPTION
## Summary
- allow recording failed downloads with custom timestamps
- pass legacy `LastFailed` values through migration and drop unused temp element
- verify migrated records keep their original `LastFailed`

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68a97df7e5808330972022985e10dcf6