### PR TITLE
Handle dispatcher during shutdown

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -188,7 +188,11 @@ namespace MyOwnGames
                 LanguageComboBox.SelectedItem = defaultItem;
             }
 
-            _logHandler = message => DispatcherQueue.TryEnqueue(() => AppendLog(message));
+            _logHandler = msg =>
+            {
+                var queue = DispatcherQueue;
+                queue?.TryEnqueue(() => AppendLog(msg));
+            };
             DebugLogger.OnLog += _logHandler;
             
             // Subscribe to image download completion events
@@ -317,7 +321,7 @@ namespace MyOwnGames
                             IconUri = "ms-appx:///Assets/no_icon.png" // Will be updated async
                         };
 
-                        DispatcherQueue.TryEnqueue(() =>
+                        DispatcherQueue?.TryEnqueue(() =>
                         {
                             GameItems.Add(entry);
                             AllGameItems.Add(entry);
@@ -365,7 +369,7 @@ namespace MyOwnGames
                     DebugLogger.LogDebug($"Image found for {appId}: {imagePath}");
                     
                     // Thread-safe UI update using DispatcherQueue with immediate priority
-                    this.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.High, () =>
+                    this.DispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.High, () =>
                     {
                         try
                         {
@@ -776,6 +780,7 @@ namespace MyOwnGames
             if (_isShuttingDown)
                 return;
             _isShuttingDown = true;
+            DebugLogger.OnLog -= _logHandler;
 
             // Cancel any ongoing operations
             _cancellationTokenSource?.Cancel();
@@ -818,8 +823,7 @@ namespace MyOwnGames
             {
                 DebugLogger.LogDebug($"Error disposing cancellation token source: {ex.Message}");
             }
-            
-            DebugLogger.OnLog -= _logHandler;
+
             DebugLogger.LogDebug($"Shutdown completed ({reason})");
         }
 


### PR DESCRIPTION
## Summary
- ensure log handler checks for DispatcherQueue availability before logging
- unsubscribe from DebugLogger events at start of shutdown
- guard DispatcherQueue usage with null-safe calls during shutdown

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68a99b20072c8330af895084b980faf8