### PR TITLE
chore: clarify GameImageService constructor

### DIFF
--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -18,9 +18,11 @@ namespace MyOwnGames.Services
 
         public GameImageService()
         {
+            // Initialize the HTTP client used for downloading images.
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.Add("User-Agent", "MyOwnGames/1.0");
 
+            // Configure the local cache for storing image files.
             var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "AchievoLab", "ImageCache");
             _cache = new GameImageCache(baseDir, new ImageFailureTrackingService());


### PR DESCRIPTION
## Summary
- document GameImageService constructor, no dispatcher queue needed anymore

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba718ee08330b79620cb1d44ce66