### PR TITLE
Copy English fallback images to English cache

### DIFF
--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -171,6 +171,7 @@ namespace MyOwnGames.Services
                     {
                         ImageDownloadCompleted?.Invoke(appId, result.Value.Path);
                     }
+                    CopyToEnglishCacheIfMissing(appId, result.Value.Path);
                     return result.Value.Path;
                 }
 
@@ -190,6 +191,38 @@ namespace MyOwnGames.Services
 
             ImageDownloadCompleted?.Invoke(appId, null);
             return null;
+        }
+
+        private void CopyToEnglishCacheIfMissing(int appId, string path)
+        {
+            try
+            {
+                if (_cache.TryGetCachedPath(appId.ToString(), "english", checkEnglishFallback: false) != null)
+                {
+                    return;
+                }
+
+                var languageDir = Path.GetDirectoryName(path);
+                if (languageDir == null)
+                {
+                    return;
+                }
+
+                var baseDir = Path.GetDirectoryName(languageDir);
+                if (baseDir == null)
+                {
+                    return;
+                }
+
+                var englishDir = Path.Combine(baseDir, "english");
+                Directory.CreateDirectory(englishDir);
+                var englishPath = Path.Combine(englishDir, Path.GetFileName(path));
+                if (!File.Exists(englishPath))
+                {
+                    File.Copy(path, englishPath);
+                }
+            }
+            catch { }
         }
 
         private async Task<string?> GetHeaderImageFromStoreApiAsync(int appId, string language)


### PR DESCRIPTION
## Summary
- Copy successful English fallback images into the English cache folder when absent
- Added helper to manage copying to the English cache

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj -p:EnableWindowsTargeting=true`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68aa4b3736d08330a7ee51ab9025d60f