### PR TITLE
Add jittered domain rate limiting

### DIFF
--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -10,7 +10,8 @@ namespace CommonUtilities
 {
     /// <summary>
     /// Shared image cache that downloads and stores images on disk with
-    /// MIME validation, cache expiration and optional failure tracking.
+    /// MIME validation, cache expiration, optional failure tracking, and
+    /// per-domain/global throttling.
     /// </summary>
     public class GameImageCache
     {


### PR DESCRIPTION
## Summary
- add base 1s delay with up to 0.5s jitter for per-domain throttling
- increase token bucket capacity to 120 with 2 tokens/sec fill rate
- document new per-domain/global throttling behavior

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68aa62f9f37c83309e7f92f57441f27c