### PR TITLE
Use concurrent dictionary for image cache

### DIFF
--- a/AnSAM.Tests/GameImageServiceTests.cs
+++ b/AnSAM.Tests/GameImageServiceTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,12 +16,12 @@ public class GameImageServiceTests
         var tracker = new ImageFailureTrackingService();
         var appId = Random.Shared.Next(900000, 1000000);
         tracker.RemoveFailedRecord(appId, "english");
-        var oldTime = DateTime.Now.AddDays(-1);
+        var oldTime = DateTime.Now.AddDays(-20);
         tracker.RecordFailedDownload(appId, "english", failedAt: oldTime);
 
         var service = new GameImageService();
         var cacheField = typeof(GameImageService).GetField("_imageCache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var dict = (Dictionary<string, string>)cacheField!.GetValue(service)!;
+        var dict = (ConcurrentDictionary<string, string>)cacheField!.GetValue(service)!;
         var cacheKey = $"{appId}_english";
         var invalidPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".bin");
         File.WriteAllText(invalidPath, "not an image");


### PR DESCRIPTION
## Summary
- replace game image cache with thread-safe `ConcurrentDictionary`
- safely remove stale entries and enumerate keys during cache clear
- adapt tests for concurrent cache and refresh failure timing

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68aa7db0a4c08330a9342dd447b93199