### PR TITLE
Track image load progress per app

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -539,6 +539,7 @@ namespace MyOwnGames
                 }
 
                 AppendLog($"Loaded {savedGamesWithLanguages.Count} saved games from {_dataService.GetXmlFilePath()}");
+                DispatcherQueue?.TryEnqueue(() => _imageService.SetTotalGames(GameItems.Count));
             }
             catch (Exception ex)
             {
@@ -797,6 +798,7 @@ namespace MyOwnGames
 
                 StatusText = $"Completed full scan: {total} games processed with {selectedLanguage} data. Current list: {GameItems.Count} games. Saved to {xmlPath}";
                 AppendLog($"Full language scan complete - Total games: {total}, All games now have {selectedLanguage} data, Current display: {GameItems.Count} games, saved to {xmlPath}");
+                DispatcherQueue?.TryEnqueue(() => _imageService.SetTotalGames(GameItems.Count));
             }
             catch (OperationCanceledException)
             {
@@ -871,6 +873,7 @@ namespace MyOwnGames
                     GameItems.Add(item);
 
                 StatusText = $"Showing {AllGameItems.Count} game(s).";
+                _imageService.SetTotalGames(GameItems.Count);
                 return;
             }
 
@@ -887,6 +890,7 @@ namespace MyOwnGames
             StatusText = filtered.Count > 0
                 ? $"Found {filtered.Count} result(s) for \"{keyword}\"."
                 : $"No results found for \"{keyword}\".";
+            _imageService.SetTotalGames(GameItems.Count);
         }
 
         private void OnWindowKeyDown(object sender, KeyRoutedEventArgs e)


### PR DESCRIPTION
## Summary
- track displayed image progress internally in GameImageService
- expose SetTotalGames to reset progress
- update MainWindow to set total images after loading or filtering

## Testing
- ❌ `dotnet build MyOwnGames/MyOwnGames.csproj -c Release -p:EnableWindowsTargeting=true` *(missing Windows build tools: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaff3b7e48330bb8f026bdea3ca98