### PR TITLE
Ensure image progress resets before scanning games

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -694,6 +694,8 @@ namespace MyOwnGames
                 return;
             }
 
+            ResetImageDownloadProgress();
+
             await EnsureSteamIdHashConsistencyAsync(steamId64!);
 
             string? xmlPath = null;
@@ -799,6 +801,7 @@ namespace MyOwnGames
                 StatusText = $"Completed full scan: {total} games processed with {selectedLanguage} data. Current list: {GameItems.Count} games. Saved to {xmlPath}";
                 AppendLog($"Full language scan complete - Total games: {total}, All games now have {selectedLanguage} data, Current display: {GameItems.Count} games, saved to {xmlPath}");
                 DispatcherQueue?.TryEnqueue(() => _imageService.SetTotalGames(GameItems.Count));
+                UpdateImageDownloadProgress();
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- Reset image progress after validating API key and Steam ID
- Recompute image download counts after updating the game list

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj`
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68aab451942483309d6b71913c851b5d