### PR TITLE
Reuse cached localized names in Steam API calls

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -580,7 +580,15 @@ namespace MyOwnGames
 
                 // Load existing games to check current language data status
                 var existingGamesData = await _dataService.LoadGamesWithLanguagesAsync();
-                
+                var existingLocalizedNames = new Dictionary<int, string>();
+                foreach (var game in existingGamesData)
+                {
+                    if (game.LocalizedNames != null && game.LocalizedNames.TryGetValue(selectedLanguage, out var name) && !string.IsNullOrEmpty(name))
+                    {
+                        existingLocalizedNames[game.AppId] = name;
+                    }
+                }
+
                 // Use real Steam API service with selected language
                 _steamService = new SteamApiService(apiKey!);
                 var total = await _steamService.GetOwnedGamesAsync(steamId64!, selectedLanguage, async game =>
@@ -632,7 +640,7 @@ namespace MyOwnGames
 
                     // Always save/update game data in XML for current language
                     await _dataService.AppendGameAsync(game, steamId64!, apiKey!, selectedLanguage);
-                }, progress, null); // Pass null to process ALL games, not just missing ones
+                }, progress, null, existingLocalizedNames); // Pass null to process ALL games, not just missing ones
 
                 xmlPath = _dataService.GetXmlFilePath();
 


### PR DESCRIPTION
## Summary
- allow GetOwnedGamesAsync to accept existing localized names and skip unnecessary API lookups
- pass known localized titles from MainWindow when scanning games

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: GameImageServiceTests.InvalidCachedImage_RemovedAndFailureRecorded)*

------
https://chatgpt.com/codex/tasks/task_e_68aaccfaf1548330b335c39a644b4aa3