### PR TITLE
Skip redundant processing for games with cached localized data

### DIFF
--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -48,6 +48,11 @@ namespace MyOwnGames.Services
 
         public string GetCurrentLanguage() => _currentLanguage;
 
+        public bool IsImageCached(int appId, string language)
+        {
+            return _cache.TryGetCachedPath(appId.ToString(), language, checkEnglishFallback: false) != null;
+        }
+
         public async Task<string?> GetGameImageAsync(int appId, string? language = null)
         {
             language ??= _currentLanguage;


### PR DESCRIPTION
## Summary
- Track localized names and cached images to build skip list
- Bypass image load and XML append for games already processed
- Expose `IsImageCached` helper in `GameImageService`

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: GameImageServiceTests.InvalidCachedImage_RemovedAndFailureRecorded)*

------
https://chatgpt.com/codex/tasks/task_e_68aacfbf60748330b9ab3583bc1d9b8d