### PR TITLE
Clear image service caches on language switch

### DIFF
--- a/AnSAM.Tests/GameImageServiceTests.cs
+++ b/AnSAM.Tests/GameImageServiceTests.cs
@@ -47,4 +47,28 @@ public class GameImageServiceTests
         tracker.RemoveFailedRecord(appId, "english");
         service.Dispose();
     }
+
+    [Fact]
+    public async Task ImageDownloadCompleted_FiresAgain_AfterLanguageChange()
+    {
+        var tracker = new ImageFailureTrackingService();
+        var appId = int.MaxValue - 1;
+        tracker.RemoveFailedRecord(appId, "english");
+        tracker.RemoveFailedRecord(appId, "german");
+
+        var service = new GameImageService();
+        int eventCount = 0;
+        service.ImageDownloadCompleted += (_, _) => eventCount++;
+
+        await service.GetGameImageAsync(appId); // initial download in english
+
+        service.SetLanguage("german");
+        await service.GetGameImageAsync(appId); // download after language switch
+
+        Assert.Equal(2, eventCount);
+
+        tracker.RemoveFailedRecord(appId, "english");
+        tracker.RemoveFailedRecord(appId, "german");
+        service.Dispose();
+    }
 }

--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -43,6 +43,11 @@ namespace MyOwnGames.Services
             {
                 _currentLanguage = language;
                 _imageCache.Clear();
+                _pendingRequests.Clear();
+                lock (_eventLock)
+                {
+                    _completedEvents.Clear();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- clear pending requests and completed event keys when switching language to ensure image downloads can refire
- add regression test for language switch event firing

## Testing
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj -p:EnableWindowsTargeting=true`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aada9f81c4833083b7128f5507f377