### PR TITLE
Ensure English cache is only populated with verified English images

### DIFF
--- a/CommonUtilities.Tests/GameImageCacheTests.cs
+++ b/CommonUtilities.Tests/GameImageCacheTests.cs
@@ -299,4 +299,39 @@ public class GameImageCacheTests : IDisposable
         var other = _cache.TryGetCachedPath(id.ToString(), "spanish", checkEnglishFallback: false);
         Assert.Null(other);
     }
+
+    [Fact]
+    public async Task NonEnglishDownloadDoesNotPopulateEnglishCache()
+    {
+        var id = Random.Shared.Next(800001, 900000);
+        int port;
+        using (var l = new TcpListener(IPAddress.Loopback, 0))
+        {
+            l.Start();
+            port = ((IPEndPoint)l.LocalEndpoint).Port;
+        }
+        var prefix = $"http://localhost:{port}/";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var serverTask = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            var data = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0, 0, 0, 0 };
+            ctx.Response.ContentType = "image/png";
+            ctx.Response.ContentLength64 = data.Length;
+            await ctx.Response.OutputStream.WriteAsync(data);
+            ctx.Response.Close();
+            listener.Stop();
+        });
+
+        var result = await _cache.GetImagePathAsync(id.ToString(), new Uri(prefix + "icon.png"), "spanish", id);
+        await serverTask;
+        Assert.True(result.Downloaded);
+
+        var englishFiles = Directory.EnumerateFiles(Path.Combine(_baseCacheDir, "english"), $"{id}.*");
+        Assert.Empty(englishFiles);
+        _tracker.RemoveFailedRecord(id, "spanish");
+    }
 }

--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -221,7 +221,6 @@ namespace MyOwnGames.Services
                     {
                         TriggerImageDownloadCompletedEvent(appId, result.Value.Path);
                     }
-                    CopyToEnglishCacheIfMissing(appId, result.Value.Path);
                     return result.Value.Path;
                 }
 
@@ -248,7 +247,8 @@ namespace MyOwnGames.Services
                 }
                 if (!string.Equals(originalLanguage, "english", StringComparison.OrdinalIgnoreCase))
                 {
-                    CopyToEnglishCacheIfMissing(appId, result.Value.Path);
+                    // Image might still be in English, but we cannot be certain;
+                    // avoid copying to the English cache to prevent contamination.
                 }
                 return result.Value.Path;
             }
@@ -330,18 +330,20 @@ namespace MyOwnGames.Services
         {
             try
             {
+                // Ensure the source file is already within the English cache
+                var sourceDir = Path.GetDirectoryName(path);
+                if (sourceDir == null ||
+                    !string.Equals(Path.GetFileName(sourceDir), "english", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
                 if (_cache.TryGetCachedPath(appId.ToString(), "english", checkEnglishFallback: false) != null)
                 {
                     return;
                 }
 
-                var languageDir = Path.GetDirectoryName(path);
-                if (languageDir == null)
-                {
-                    return;
-                }
-
-                var baseDir = Path.GetDirectoryName(languageDir);
+                var baseDir = Path.GetDirectoryName(sourceDir);
                 if (baseDir == null)
                 {
                     return;


### PR DESCRIPTION
## Summary
- Avoid copying image results to the English cache unless the language is verified
- Guard `CopyToEnglishCacheIfMissing` so it only copies from the English cache
- Test that non-English downloads do not create files in the English cache

## Testing
- ⚠️ `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.)*
- ✅ `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68aaf621d2048330893f112fabe2414d