### PR TITLE
Remove unused English cache copy helper

### DIFF
--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -237,41 +237,6 @@ namespace MyOwnGames.Services
             }
             ImageDownloadCompleted?.Invoke(appId, path);
         }
-
-        private void CopyToEnglishCacheIfMissing(int appId, string path)
-        {
-            try
-            {
-                // Ensure the source file is already within the English cache
-                var sourceDir = Path.GetDirectoryName(path);
-                if (sourceDir == null ||
-                    !string.Equals(Path.GetFileName(sourceDir), "english", StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-
-                if (_cache.TryGetCachedPath(appId.ToString(), "english", checkEnglishFallback: false) != null)
-                {
-                    return;
-                }
-
-                var baseDir = Path.GetDirectoryName(sourceDir);
-                if (baseDir == null)
-                {
-                    return;
-                }
-
-                var englishDir = Path.Combine(baseDir, "english");
-                Directory.CreateDirectory(englishDir);
-                var englishPath = Path.Combine(englishDir, Path.GetFileName(path));
-                if (!File.Exists(englishPath))
-                {
-                    File.Copy(path, englishPath);
-                }
-            }
-            catch { }
-        }
-
         private async Task<string?> GetHeaderImageFromStoreApiAsync(int appId, string language)
         {
             try


### PR DESCRIPTION
## Summary
- Delete `CopyToEnglishCacheIfMissing` helper from `GameImageService`

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -p:EnableWindowsTargeting=true -p:WindowsSdkPackageVersion=10.0.22621.38` *(fails: XamlCompiler.exe Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab012cf9b8833093c5af6a03bb1621