### PR TITLE
Refactor image validation and add tests

### DIFF
--- a/CommonUtilities.Tests/ImageValidationTests.cs
+++ b/CommonUtilities.Tests/ImageValidationTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using CommonUtilities;
+using Xunit;
+
+public class ImageValidationTests
+{
+    public static TheoryData<byte[], string> ValidHeaders => new()
+    {
+        { new byte[] { 0x89, 0x50, 0x4E, 0x47 }, ".png" },
+        { new byte[] { 0xFF, 0xD8, 0xFF, 0xDB }, ".jpg" },
+        { new byte[] { 0x47, 0x49, 0x46, 0x38 }, ".gif" },
+        { new byte[] { 0x42, 0x4D, 0, 0 }, ".bmp" },
+        { new byte[] { 0x00, 0x00, 0x01, 0x00, 0, 0 }, ".ico" },
+        { new byte[] { 0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66 }, ".avif" },
+        { new byte[] { 0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50 }, ".webp" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidHeaders))]
+    public void SupportedFormatsAreValid(byte[] data, string ext)
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ext);
+        File.WriteAllBytes(path, data);
+        try
+        {
+            Assert.True(ImageValidation.IsValidImage(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void InvalidImageIsRejected()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        File.WriteAllBytes(path, new byte[] { 1, 2, 3, 4 });
+        try
+        {
+            Assert.False(ImageValidation.IsValidImage(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}
+

--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -411,39 +411,17 @@ namespace CommonUtilities
         {
             try
             {
-                var info = new FileInfo(path);
-                if (!info.Exists || info.Length == 0)
+                if (!ImageValidation.IsValidImage(path))
                 {
                     return false;
                 }
 
+                var info = new FileInfo(path);
                 if (DateTime.UtcNow - info.LastWriteTimeUtc > _cacheDuration)
                 {
                     return false;
                 }
-
-                Span<byte> header = stackalloc byte[12];
-                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                int read = fs.Read(header);
-                if (read >= 4)
-                {
-                    if (header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47)
-                        return true; // PNG
-                    if (header[0] == 0xFF && header[1] == 0xD8)
-                        return true; // JPEG
-                    if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46)
-                        return true; // GIF
-                    if (header[0] == 0x42 && header[1] == 0x4D)
-                        return true; // BMP
-                    if (header[0] == 0x00 && header[1] == 0x00 && header[2] == 0x01 && header[3] == 0x00)
-                        return true; // ICO
-                    if (read >= 12 && header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70 &&
-                        header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66)
-                        return true; // AVIF
-                    if (read >= 12 && header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
-                        header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)
-                        return true; // WEBP
-                }
+                return true;
             }
             catch { }
             return false;

--- a/CommonUtilities/ImageValidation.cs
+++ b/CommonUtilities/ImageValidation.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+
+namespace CommonUtilities
+{
+    public static class ImageValidation
+    {
+        public static bool IsValidImage(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                if (!info.Exists || info.Length == 0)
+                {
+                    return false;
+                }
+
+                Span<byte> header = stackalloc byte[12];
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                int read = fs.Read(header);
+                if (read >= 4)
+                {
+                    if (header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47)
+                        return true; // PNG
+                    if (header[0] == 0xFF && header[1] == 0xD8)
+                        return true; // JPEG
+                    if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46)
+                        return true; // GIF
+                    if (header[0] == 0x42 && header[1] == 0x4D)
+                        return true; // BMP
+                    if (header[0] == 0x00 && header[1] == 0x00 && header[2] == 0x01 && header[3] == 0x00)
+                        return true; // ICO
+                    if (read >= 12 && header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70 &&
+                        header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66)
+                        return true; // AVIF
+                    if (read >= 12 && header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
+                        header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)
+                        return true; // WEBP
+                }
+            }
+            catch { }
+            return false;
+        }
+    }
+}
+

--- a/MyOwnGames/Services/GameImageService.cs
+++ b/MyOwnGames/Services/GameImageService.cs
@@ -91,7 +91,7 @@ namespace MyOwnGames.Services
 
             if (_imageCache.TryGetValue(cacheKey, out var cached))
             {
-                if (IsValidImage(cached))
+                if (IsFreshImage(cached))
                 {
                     return cached;
                 }
@@ -165,7 +165,7 @@ namespace MyOwnGames.Services
 
             var languageUrls = RoundRobin(languageSpecificUrlMap);
             var result = await _cache.GetImagePathAsync(appId.ToString(), languageUrls, language, appId);
-            if (!string.IsNullOrEmpty(result?.Path) && IsValidImage(result.Value.Path))
+            if (!string.IsNullOrEmpty(result?.Path) && IsFreshImage(result.Value.Path))
             {
                 _imageCache[cacheKey] = result.Value.Path;
                 if (result.Value.Downloaded)
@@ -187,7 +187,7 @@ namespace MyOwnGames.Services
 
             var logoUrls = RoundRobin(logoUrlMap);
             result = await _cache.GetImagePathAsync(appId.ToString(), logoUrls, originalLanguage, appId);
-            if (!string.IsNullOrEmpty(result?.Path) && IsValidImage(result.Value.Path))
+            if (!string.IsNullOrEmpty(result?.Path) && IsFreshImage(result.Value.Path))
             {
                 _imageCache[cacheKey] = result.Value.Path;
                 if (result.Value.Downloaded)
@@ -321,43 +321,21 @@ namespace MyOwnGames.Services
             _imageCache.Clear();
         }
 
-        private static bool IsValidImage(string path)
+        private static bool IsFreshImage(string path)
         {
             try
             {
-                var info = new FileInfo(path);
-                if (!info.Exists || info.Length == 0)
+                if (!ImageValidation.IsValidImage(path))
                 {
                     return false;
                 }
 
+                var info = new FileInfo(path);
                 if (DateTime.UtcNow - info.LastWriteTimeUtc > TimeSpan.FromDays(30))
                 {
                     return false;
                 }
-
-                Span<byte> header = stackalloc byte[12];
-                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                int read = fs.Read(header);
-                if (read >= 4)
-                {
-                    if (header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47)
-                        return true; // PNG
-                    if (header[0] == 0xFF && header[1] == 0xD8)
-                        return true; // JPEG
-                    if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46)
-                        return true; // GIF
-                    if (header[0] == 0x42 && header[1] == 0x4D)
-                        return true; // BMP
-                    if (header[0] == 0x00 && header[1] == 0x00 && header[2] == 0x01 && header[3] == 0x00)
-                        return true; // ICO
-                    if (read >= 12 && header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70 &&
-                        header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66)
-                        return true; // AVIF
-                    if (read >= 12 && header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
-                        header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)
-                        return true; // WEBP
-                }
+                return true;
             }
             catch { }
             return false;


### PR DESCRIPTION
## Summary
- centralize image validation into CommonUtilities.ImageValidation
- use the helper in GameImageService and GameImageCache to remove duplicate logic
- test supported image formats and invalid files

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj --no-build`
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68ab03aae9e4833080bfa7a72ba411fa