### PR TITLE
test image redownload event uses new language folder

### DIFF
--- a/AnSAM.sln
+++ b/AnSAM.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonUtilities", "CommonUt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonUtilities.Tests", "CommonUtilities.Tests\CommonUtilities.Tests.csproj", "{FC0056D5-9761-48B6-9F20-DAF33E11AF0E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyOwnGames.Tests", "MyOwnGames.Tests\MyOwnGames.Tests.csproj", "{3E1CABA5-F07C-4A26-8DAE-B2824F786CF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -48,11 +50,15 @@ Global
 		{B7810BFE-602D-41D1-AF6D-A2229C3B63F2}.Release|x64.ActiveCfg = Release|Any CPU
 		{B7810BFE-602D-41D1-AF6D-A2229C3B63F2}.Release|x64.Build.0 = Release|Any CPU
 		{FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Debug|x64.Build.0 = Debug|Any CPU
-		{FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Release|x64.ActiveCfg = Release|Any CPU
-		{FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Release|x64.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Debug|x64.Build.0 = Debug|Any CPU
+                {FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Release|x64.ActiveCfg = Release|Any CPU
+                {FC0056D5-9761-48B6-9F20-DAF33E11AF0E}.Release|x64.Build.0 = Release|Any CPU
+                {3E1CABA5-F07C-4A26-8DAE-B2824F786CF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {3E1CABA5-F07C-4A26-8DAE-B2824F786CF2}.Debug|x64.Build.0 = Debug|Any CPU
+                {3E1CABA5-F07C-4A26-8DAE-B2824F786CF2}.Release|x64.ActiveCfg = Release|Any CPU
+                {3E1CABA5-F07C-4A26-8DAE-B2824F786CF2}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonUtilities;
+using MyOwnGames.Services;
+using Xunit;
+
+public class GameImageServiceLanguageTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly GameImageService _service;
+
+    public GameImageServiceLanguageTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+
+        _service = new GameImageService();
+
+        // Replace internal HttpClient used for store API
+        var storeField = typeof(GameImageService).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        storeField.SetValue(_service, new HttpClient(new FakeStoreApiHandler()));
+
+        // Replace internal cache with one that uses our fake image handler and temp directory
+        var cache = new GameImageCache(_tempDir, new ImageFailureTrackingService());
+        var httpField = typeof(GameImageCache).GetField("_http", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        httpField.SetValue(cache, new HttpClient(new FakeImageHandler()));
+        var cacheField = typeof(GameImageService).GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        cacheField.SetValue(_service, cache);
+    }
+
+    [Fact]
+    public async Task RedownloadsImage_WhenLanguageChanges_FiresEventWithNewLanguagePath()
+    {
+        var appId = 12345;
+        string? lastPath = null;
+        int eventCount = 0;
+        _service.ImageDownloadCompleted += (_, path) => { eventCount++; lastPath = path; };
+
+        var firstPath = await _service.GetGameImageAsync(appId); // initial english download
+        Assert.NotNull(firstPath);
+        Assert.Contains(Path.Combine(_tempDir, "english"), firstPath!);
+
+        // Remove the english cache to force a redownload for the next language
+        Directory.Delete(Path.Combine(_tempDir, "english"), true);
+
+        _service.SetLanguage("german");
+        var secondPath = await _service.GetGameImageAsync(appId); // force redownload with english fallback
+
+        Assert.NotNull(secondPath);
+        Assert.Contains(Path.Combine(_tempDir, "german"), secondPath!);
+        Assert.Equal(secondPath, lastPath);
+        Assert.Equal(2, eventCount);
+    }
+
+    public void Dispose()
+    {
+        _service.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private class FakeStoreApiHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var lang = request.RequestUri!.Query.Contains("l=german") ? "german" : "english";
+            var json = $"{{\"12345\":{{\"success\":true,\"data\":{{\"header_image\":\"https://example.com/header_{lang}.jpg\"}}}}}}";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private class FakeImageHandler : HttpMessageHandler
+    {
+        private static readonly byte[] PngBytes = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfZp8AAAAASUVORK5CYII=");
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.AbsoluteUri;
+            if (url.Contains("header_german") || url.Contains("logo_german"))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(PngBytes)
+            };
+            resp.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+            return Task.FromResult(resp);
+        }
+    }
+}

--- a/MyOwnGames.Tests/MyOwnGames.Tests.csproj
+++ b/MyOwnGames.Tests/MyOwnGames.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../MyOwnGames/Services/GameImageService.cs" Link="GameImageService.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CommonUtilities/CommonUtilities.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add MyOwnGames.Tests project with GameImageService redownload test
- mock store and image requests to avoid external calls
- verify ImageDownloadCompleted re-fires and caches under new language

## Testing
- `dotnet test MyOwnGames.Tests/MyOwnGames.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab0598fefc833095b41e4a999d908a