### PR TITLE
Include steam cache IDs in user games refresh

### DIFF
--- a/AnSAM/Services/GameCacheService.cs
+++ b/AnSAM/Services/GameCacheService.cs
@@ -35,13 +35,38 @@ namespace AnSAM.Services
             var result = new List<SteamAppData>();
             if (steam.Initialized)
             {
-                foreach (var game in GameListService.Games)
+                var ids = new HashSet<int>(GameListService.Games.Select(g => g.Id));
+
+                var steamGamesPath = Path.Combine(cacheDir, "steam_games.xml");
+                if (File.Exists(steamGamesPath))
                 {
-                    uint appId = (uint)game.Id;
+                    try
+                    {
+                        var doc = XDocument.Load(steamGamesPath);
+                        foreach (var node in doc.Descendants("AppID"))
+                        {
+                            if (int.TryParse(node.Value, out var id))
+                                ids.Add(id);
+                        }
+                        foreach (var node in doc.Descendants("Game"))
+                        {
+                            if (int.TryParse(node.Attribute("AppID")?.Value, out var id))
+                                ids.Add(id);
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore corrupt steam_games.xml
+                    }
+                }
+
+                foreach (var id in ids)
+                {
+                    uint appId = (uint)id;
                     if (!steam.IsSubscribedApp(appId))
                         continue;
                     var title = steam.GetAppData(appId, "name") ?? appId.ToString(CultureInfo.InvariantCulture);
-                    result.Add(new SteamAppData(game.Id, title));
+                    result.Add(new SteamAppData(id, title));
                 }
 
                 try


### PR DESCRIPTION
## Summary
- Load extra app IDs from `steam_games.xml` and merge with global list before verifying ownership.
- Persist merged IDs back to `usergames.xml`.
- Regression test covers IDs only in `steam_games.xml` and verifies image retrieval from cache.

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68ab20ad83388330ba6012e79528e751