### PR TITLE
Await pending image requests on language change

### DIFF
--- a/AnSAM.Tests/GameImageServiceTests.cs
+++ b/AnSAM.Tests/GameImageServiceTests.cs
@@ -62,7 +62,7 @@ public class GameImageServiceTests
 
         await service.GetGameImageAsync(appId); // initial download in english
 
-        service.SetLanguage("german");
+        await service.SetLanguage("german");
         await service.GetGameImageAsync(appId); // download after language switch
 
         Assert.Equal(2, eventCount);

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -129,7 +129,7 @@ namespace AnSAM
 
             LanguageComboBox.SelectedItem = initial;
             SteamLanguageResolver.OverrideLanguage = initial;
-            _imageService.SetLanguage(initial);
+            _imageService.SetLanguage(initial).GetAwaiter().GetResult();
             _languageInitialized = true;
         }
         private void ApplyTheme(ElementTheme theme, bool save = true)
@@ -178,7 +178,7 @@ namespace AnSAM
             if (LanguageComboBox.SelectedItem is string lang)
             {
                 SteamLanguageResolver.OverrideLanguage = lang;
-                _imageService.SetLanguage(lang);
+                await _imageService.SetLanguage(lang);
 
                 try
                 {

--- a/MyOwnGames.Tests/GameImageServiceCancellationTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceCancellationTests.cs
@@ -45,7 +45,7 @@ public class GameImageServiceCancellationTests : IDisposable
         var appId = 12345;
         var downloadTask = _service.GetGameImageAsync(appId);
         await Task.Delay(100);
-        _service.SetLanguage("german");
+        await _service.SetLanguage("german");
 
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await downloadTask);
         Assert.False(_tracker.ShouldSkipDownload(appId, "english"));

--- a/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
@@ -48,7 +48,7 @@ public class GameImageServiceLanguageTests : IDisposable
         // Remove the english cache to force a redownload for the next language
         Directory.Delete(Path.Combine(_tempDir, "english"), true);
 
-        _service.SetLanguage("german");
+        await _service.SetLanguage("german");
         var secondPath = await _service.GetGameImageAsync(appId); // force redownload with english fallback
 
         Assert.NotNull(secondPath);

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -223,7 +223,7 @@ namespace MyOwnGames
 
             // Initialize image service with default language
             var initialLanguage = GetCurrentLanguage();
-            _imageService.SetLanguage(initialLanguage);
+            _imageService.SetLanguage(initialLanguage).GetAwaiter().GetResult();
             AppendLog($"Initialized with language: {initialLanguage}");
 
             // Subscribe to scroll events for on-demand image loading - defer until after UI is loaded
@@ -343,7 +343,7 @@ namespace MyOwnGames
                 var currentLanguage = GetCurrentLanguage();
 
                 // Update image service language
-                _imageService.SetLanguage(currentLanguage);
+                await _imageService.SetLanguage(currentLanguage);
 
                 GameItems.Clear();
                 AllGameItems.Clear();
@@ -992,7 +992,7 @@ namespace MyOwnGames
             return _defaultLanguage;
         }
 
-        private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_isLoading || LanguageComboBox.SelectedItem == null)
                 return;
@@ -1017,7 +1017,10 @@ namespace MyOwnGames
                 _isLoading = true;
 
                 // Update image service language first
-                _imageService?.SetLanguage(newLanguage);
+                if (_imageService != null)
+                {
+                    await _imageService.SetLanguage(newLanguage);
+                }
 
                 // Clear tracking for previous language
                 if (!string.IsNullOrEmpty(currentImageServiceLanguage))


### PR DESCRIPTION
## Summary
- ensure `SetLanguage` awaits in-flight image requests and resets cache safely
- update UI and tests to await the new async `SetLanguage`

## Testing
- `dotnet test AnSAM.sln` *(fails: GameImageServiceLanguageTests.RedownloadsImage_WhenLanguageChanges_FiresEventWithNewLanguagePath - proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e38582c8330ad466d2715b7dd5e