### PR TITLE
Handle game list download errors

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -190,7 +190,30 @@ namespace AnSAM
                     // Ignore inability to persist settings
                 }
 
-                await RefreshAsync();
+                try
+                {
+                    await RefreshAsync();
+                }
+                catch (Exception ex)
+                {
+                    StatusProgress.IsIndeterminate = false;
+                    StatusProgress.Value = 0;
+                    StatusExtra.Text = string.Empty;
+                    StatusText.Text = "Refresh failed";
+
+                    DebugLogger.LogDebug(ex.ToString());
+
+                    var dialog = new ContentDialog
+                    {
+                        Title = "Refresh failed",
+                        Content = "Unable to refresh game list. Please try again.",
+                        CloseButtonText = "OK",
+                        XamlRoot = Content.XamlRoot
+                    };
+
+                    await dialog.ShowAsync();
+                    StatusText.Text = "Ready";
+                }
             }
         }
 

--- a/AnSAM/Services/GameCacheService.cs
+++ b/AnSAM/Services/GameCacheService.cs
@@ -30,7 +30,14 @@ namespace AnSAM.Services
             Directory.CreateDirectory(cacheDir);
             var userGamesPath = Path.Combine(cacheDir, "usergames.xml");
 
-            await GameListService.LoadAsync(cacheDir, http).ConfigureAwait(false);
+            try
+            {
+                await GameListService.LoadAsync(cacheDir, http).ConfigureAwait(false);
+            }
+            catch (GameListDownloadException ex)
+            {
+                throw new InvalidOperationException("Unable to download game list. Please try again later.", ex);
+            }
 
             var result = new List<SteamAppData>();
             if (steam.Initialized)


### PR DESCRIPTION
## Summary
- Guard `GameListService.LoadAsync` against HTTP failures and fall back to cached data, raising a dedicated `GameListDownloadException` when no cache is available.
- Propagate user-friendly errors from `GameCacheService.RefreshAsync` when the game list cannot be downloaded.
- Prevent unhandled exceptions in `MainWindow.LanguageComboBox_SelectionChanged` by catching refresh errors and showing a dialog.

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68abba576f5c8330b8f3f77432aa312a