### PR TITLE
Reduce default domain concurrency limits

### DIFF
--- a/CommonUtilities/DomainRateLimiter.cs
+++ b/CommonUtilities/DomainRateLimiter.cs
@@ -21,7 +21,7 @@ namespace CommonUtilities
         private double _tokens;
         private DateTime _lastRefill;
 
-        public DomainRateLimiter(int maxConcurrentRequestsPerDomain = 4, double capacity = 120, double fillRatePerSecond = 2, double initialTokens = -1)
+        public DomainRateLimiter(int maxConcurrentRequestsPerDomain = 2, double capacity = 120, double fillRatePerSecond = 2, double initialTokens = -1)
         {
             _maxConcurrentRequestsPerDomain = maxConcurrentRequestsPerDomain;
             _capacity = capacity;

--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -47,7 +47,7 @@ namespace CommonUtilities
             ImageFailureTrackingService? failureTracker = null,
             int maxConcurrency = 4,
             TimeSpan? cacheDuration = null,
-            int maxConcurrentRequestsPerDomain = 4,
+            int maxConcurrentRequestsPerDomain = 2,
             int tokenBucketCapacity = 120,
             double fillRatePerSecond = 2,
             double? initialTokens = null)


### PR DESCRIPTION
## Summary
- lower DomainRateLimiter default maxConcurrentRequestsPerDomain from 4 to 2
- lower GameImageCache default domain concurrency to match new limiter default

## Testing
- `dotnet build` *(fails: /root/.nuget/.../XamlCompiler.exe: Exec format error)*
- `dotnet build CommonUtilities/CommonUtilities.csproj`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: Parameter count mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68abc75833008330b904ae1ee68eb3e4