### PR TITLE
Throttle-aware image download logging

### DIFF
--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -311,6 +311,7 @@ namespace CommonUtilities
                 try
                 {
                     await _rateLimiter.WaitAsync(uri).ConfigureAwait(false);
+                    DebugLogger.LogDebug($"Starting image download for {uri}");
                     using var response = await _http.GetAsync(uri, cancellationToken).ConfigureAwait(false);
                     if (!response.IsSuccessStatusCode)
                     {

--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -120,9 +120,6 @@ namespace CommonUtilities
                 // Don't record as failed download - file was corrupted, not missing
             }
 
-            // Only log when we actually need to download
-            DebugLogger.LogDebug($"Starting image download for {appId} (language: {language})");
-            
             var languageSpecificUrlMap = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
             static void AddUrl(Dictionary<string, List<string>> map, string url)


### PR DESCRIPTION
## Summary
- log outbound image requests after rate-limiter waits in `GameImageCache`
- remove pre-throttle image download log from `SharedImageService`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68abcaef4b208330a3e936ecfec48310