### PR TITLE
Refactor DomainRateLimiter token timing

### DIFF
--- a/CommonUtilities/DomainRateLimiter.cs
+++ b/CommonUtilities/DomainRateLimiter.cs
@@ -18,7 +18,6 @@ namespace CommonUtilities
         private readonly int _maxConcurrentRequestsPerDomain;
         private readonly double _capacity;
         private readonly double _fillRatePerSecond;
-        private readonly bool _consumeTokenBeforeDomainDelay;
         private double _tokens;
         private DateTime _lastRefill;
 
@@ -26,13 +25,11 @@ namespace CommonUtilities
             int maxConcurrentRequestsPerDomain = 2,
             double capacity = 60,
             double fillRatePerSecond = 1,
-            double initialTokens = -1,
-            bool consumeTokenBeforeDomainDelay = true)
+            double initialTokens = -1)
         {
             _maxConcurrentRequestsPerDomain = maxConcurrentRequestsPerDomain;
             _capacity = capacity;
             _fillRatePerSecond = fillRatePerSecond;
-            _consumeTokenBeforeDomainDelay = consumeTokenBeforeDomainDelay;
             _tokens = initialTokens >= 0 ? initialTokens : capacity;
             _lastRefill = DateTime.UtcNow;
         }
@@ -60,99 +57,63 @@ namespace CommonUtilities
             {
                 var minInterval = BaseDomainDelay + TimeSpan.FromSeconds(Random.Shared.NextDouble() * JitterSeconds);
 
-                if (_consumeTokenBeforeDomainDelay)
+                while (true)
                 {
-                    while (true)
-                    {
-                        TimeSpan tokenDelay;
-                        lock (_lock)
-                        {
-                            RefillTokens(DateTime.UtcNow);
-                            if (_tokens >= 1)
-                            {
-                                _tokens -= 1;
-                                _totalRequestsProcessed++;
-                                DebugLogger.LogDebug($"Token consumed for {host}, tokens remaining: {_tokens:F2}, total processed: {_totalRequestsProcessed}");
-                                tokenDelay = TimeSpan.Zero;
-                            }
-                            else
-                            {
-                                var needed = 1 - _tokens;
-                                tokenDelay = TimeSpan.FromSeconds(needed / _fillRatePerSecond);
-                            }
-                        }
-
-                        if (tokenDelay > TimeSpan.Zero)
-                        {
-                            await Task.Delay(tokenDelay).ConfigureAwait(false);
-                            continue;
-                        }
-                        break;
-                    }
-
-                    TimeSpan domainDelay = TimeSpan.Zero;
+                    TimeSpan tokenDelay;
                     lock (_lock)
                     {
-                        if (_lastCall.TryGetValue(host, out var last))
+                        var now = DateTime.UtcNow;
+                        var elapsed = (now - _lastRefill).TotalSeconds;
+                        var available = Math.Min(_capacity, _tokens + elapsed * _fillRatePerSecond);
+                        if (available >= 1)
                         {
-                            var since = DateTime.UtcNow - last;
-                            if (since < minInterval)
-                            {
-                                domainDelay = minInterval - since;
-                            }
+                            _tokens = available - 1;
+                            _lastRefill = now;
+                            _totalRequestsProcessed++;
+                            DebugLogger.LogDebug($"Token consumed for {host}, tokens remaining: {_tokens:F2}, total processed: {_totalRequestsProcessed}");
+                            tokenDelay = TimeSpan.Zero;
+                        }
+                        else
+                        {
+                            tokenDelay = TimeSpan.FromSeconds((1 - available) / _fillRatePerSecond);
                         }
                     }
 
-                    if (domainDelay > TimeSpan.Zero)
+                    if (tokenDelay > TimeSpan.Zero)
                     {
-                        await Task.Delay(domainDelay).ConfigureAwait(false);
-                    }
-
-                    return;
-                }
-                else
-                {
-                    while (true)
-                    {
-                        TimeSpan delay = TimeSpan.Zero;
+                        await Task.Delay(tokenDelay).ConfigureAwait(false);
                         lock (_lock)
                         {
-                            // domain delay
-                            if (_lastCall.TryGetValue(host, out var last))
-                            {
-                                var since = DateTime.UtcNow - last;
-                                if (since < minInterval)
-                                {
-                                    delay = minInterval - since;
-                                }
-                            }
-
                             RefillTokens(DateTime.UtcNow);
-                            if (_tokens >= 1 && delay == TimeSpan.Zero)
-                            {
-                                _tokens -= 1;
-                                _totalRequestsProcessed++;
-                                DebugLogger.LogDebug($"Token consumed for {host}, tokens remaining: {_tokens:F2}, total processed: {_totalRequestsProcessed}");
-                                // Don't release semaphore here - it will be released in RecordCall
-                                return;
-                            }
-                            if (_tokens < 1)
-                            {
-                                var needed = 1 - _tokens;
-                                var tokenDelay = TimeSpan.FromSeconds(needed / _fillRatePerSecond);
-                                if (tokenDelay > delay)
-                                {
-                                    delay = tokenDelay;
-                                }
-                            }
                         }
+                        continue;
+                    }
+                    break;
+                }
 
-                        if (delay > TimeSpan.Zero)
+                TimeSpan domainDelay = TimeSpan.Zero;
+                lock (_lock)
+                {
+                    if (_lastCall.TryGetValue(host, out var last))
+                    {
+                        var since = DateTime.UtcNow - last;
+                        if (since < minInterval)
                         {
-                            await Task.Delay(delay).ConfigureAwait(false);
+                            domainDelay = minInterval - since;
                         }
                     }
                 }
+
+                if (domainDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(domainDelay).ConfigureAwait(false);
+                    lock (_lock)
+                    {
+                        RefillTokens(DateTime.UtcNow);
+                    }
+                }
+
+                return;
             }
             catch
             {

--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -50,8 +50,7 @@ namespace CommonUtilities
             int maxConcurrentRequestsPerDomain = 2,
             int tokenBucketCapacity = 60,
             double fillRatePerSecond = 1,
-            double? initialTokens = null,
-            bool consumeTokenBeforeDomainDelay = true)
+            double? initialTokens = null)
         {
             _baseCacheDir = baseCacheDir;
             Directory.CreateDirectory(_baseCacheDir);
@@ -59,7 +58,7 @@ namespace CommonUtilities
             _concurrency = new SemaphoreSlim(maxConcurrency);
             _cacheDuration = cacheDuration ?? TimeSpan.FromDays(30);
 
-            _rateLimiter = new DomainRateLimiter(maxConcurrentRequestsPerDomain, tokenBucketCapacity, fillRatePerSecond, initialTokens ?? tokenBucketCapacity, consumeTokenBeforeDomainDelay);
+            _rateLimiter = new DomainRateLimiter(maxConcurrentRequestsPerDomain, tokenBucketCapacity, fillRatePerSecond, initialTokens ?? tokenBucketCapacity);
 
             // Configure HttpClient with proper timeout and headers
             _http = new HttpClient();


### PR DESCRIPTION
## Summary
- ensure tokens are refilled after any wait delays
- consume token before domain wait so attempts count globally

## Testing
- `dotnet test -v minimal` *(failed: GameImageServiceLanguageTests.RedownloadsImage_WhenLanguageChanges_FiresEventWithNewLanguagePath)*
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68abcbe546e88330b396f52cc0e8b5ab