### PR TITLE
Use generic English header image

### DIFF
--- a/CommonUtilities.Tests/GameImageCacheTests.cs
+++ b/CommonUtilities.Tests/GameImageCacheTests.cs
@@ -424,11 +424,18 @@ public class GameImageCacheTests : IDisposable
 
         // Invoke English fallback via reflection
         var method = typeof(GameImageCache).GetMethod("TryEnglishFallbackAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-        var task = (Task<GameImageCache.ImageResult?>)method!.Invoke(_cache, new object?[] { id.ToString(), "spanish", id })!;
+        var task = (Task<GameImageCache.ImageResult?>)method!.Invoke(
+            _cache,
+            new object?[] { id.ToString(), "spanish", id, CancellationToken.None })!;
         var fallback = await task;
         Assert.NotNull(fallback);
         var spanishPath = fallback.Value.Path;
         Assert.True(File.Exists(spanishPath));
+
+        // English cache should also contain the downloaded image
+        var englishPath = _cache.TryGetCachedPath(id.ToString(), "english", checkEnglishFallback: false);
+        Assert.NotNull(englishPath);
+        Assert.True(File.Exists(englishPath));
 
         // Failure record for Spanish should be cleared
         Assert.False(_tracker.ShouldSkipDownload(id, "spanish"));

--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -170,14 +170,28 @@ namespace CommonUtilities
             //    AddUrl(languageSpecificUrlMap, $"https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg");
             //}
 
-            // Cloudflare CDN
-            AddUrl(languageSpecificUrlMap, $"https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg");
+            if (string.Equals(language, "english", StringComparison.OrdinalIgnoreCase))
+            {
+                // Cloudflare CDN
+                AddUrl(languageSpecificUrlMap, $"https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/{appId}/header.jpg");
 
-            // Steam CDN
-            AddUrl(languageSpecificUrlMap, $"https://cdn.steamstatic.com/steam/apps/{appId}/header_{language}.jpg");
+                // Steam CDN
+                AddUrl(languageSpecificUrlMap, $"https://cdn.steamstatic.com/steam/apps/{appId}/header.jpg");
 
-            // Akamai CDN
-            AddUrl(languageSpecificUrlMap, $"https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg");
+                // Akamai CDN
+                AddUrl(languageSpecificUrlMap, $"https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/{appId}/header.jpg");
+            }
+            else
+            {
+                // Cloudflare CDN
+                AddUrl(languageSpecificUrlMap, $"https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg");
+
+                // Steam CDN
+                AddUrl(languageSpecificUrlMap, $"https://cdn.steamstatic.com/steam/apps/{appId}/header_{language}.jpg");
+
+                // Akamai CDN
+                AddUrl(languageSpecificUrlMap, $"https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg");
+            }
 
             var languageUrls = RoundRobin(languageSpecificUrlMap);
             var result = await _cache.GetImagePathAsync(appId.ToString(), languageUrls, language, appId, _cts.Token);


### PR DESCRIPTION
## Summary
- Add explicit header.jpg URLs for English in SharedImageService and keep language-suffixed variants for other languages
- Ensure English fallback images are cached under the English directory and add unit test coverage

## Testing
- `dotnet test`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68abd0c5a6708330bf19f53ef36d8096