### PR TITLE
test: correct English header URL in image service test

### DIFF
--- a/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using CommonUtilities;
 using Xunit;
 
@@ -13,6 +14,7 @@ public class GameImageServiceLanguageTests : IDisposable
 {
     private readonly string _tempDir;
     private readonly SharedImageService _service;
+    private readonly FakeImageHandler _imageHandler;
 
     public GameImageServiceLanguageTests()
     {
@@ -27,8 +29,9 @@ public class GameImageServiceLanguageTests : IDisposable
 
         // Replace internal cache with one that uses our fake image handler and temp directory
         var cache = new GameImageCache(_tempDir, new ImageFailureTrackingService());
+        _imageHandler = new FakeImageHandler();
         var httpField = typeof(GameImageCache).GetField("_http", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        httpField.SetValue(cache, new HttpClient(new FakeImageHandler()));
+        httpField.SetValue(cache, new HttpClient(_imageHandler));
         var cacheField = typeof(SharedImageService).GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         cacheField.SetValue(_service, cache);
     }
@@ -44,6 +47,8 @@ public class GameImageServiceLanguageTests : IDisposable
         var firstPath = await _service.GetGameImageAsync(appId); // initial english download
         Assert.NotNull(firstPath);
         Assert.Contains(Path.Combine(_tempDir, "english"), firstPath!);
+        Assert.Contains("https://example.com/header.jpg", _imageHandler.RequestedUrls);
+        Assert.DoesNotContain(_imageHandler.RequestedUrls, url => url.Contains("header_english"));
 
         // Remove the english cache to force a redownload for the next language
         Directory.Delete(Path.Combine(_tempDir, "english"), true);
@@ -68,7 +73,8 @@ public class GameImageServiceLanguageTests : IDisposable
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var lang = request.RequestUri!.Query.Contains("l=german") ? "german" : "english";
-            var json = $"{{\"12345\":{{\"success\":true,\"data\":{{\"header_image\":\"https://example.com/header_{lang}.jpg\"}}}}}}";
+            var headerUrl = lang == "german" ? "https://example.com/header_german.jpg" : "https://example.com/header.jpg";
+            var json = $"{{\"12345\":{{\"success\":true,\"data\":{{\"header_image\":\"{headerUrl}\"}}}}}}";
             var response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -79,13 +85,17 @@ public class GameImageServiceLanguageTests : IDisposable
 
     private class FakeImageHandler : HttpMessageHandler
     {
+        public List<string> RequestedUrls { get; } = new();
+
         private static readonly byte[] PngBytes = Convert.FromBase64String(
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfZp8AAAAASUVORK5CYII=");
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var url = request.RequestUri!.AbsoluteUri;
-            if (url.Contains("header_german") || url.Contains("logo_german"))
+            RequestedUrls.Add(url);
+            if (url.Contains("header_german") || url.Contains("logo_german") ||
+                url.Contains("header_english") || url.Contains("logo_english"))
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
             }


### PR DESCRIPTION
## Summary
- ensure store API handler emits `header.jpg` for English responses
- verify image handler downloads from English URL and rejects old `header_english` paths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd3d6b3c0833087a6b9598e9473e1