### PR TITLE
Handle image download cancellations

### DIFF
--- a/MyOwnGames.Tests/GameImageServiceCancellationTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceCancellationTests.cs
@@ -47,7 +47,8 @@ public class GameImageServiceCancellationTests : IDisposable
         await Task.Delay(100);
         await _service.SetLanguage("german");
 
-        await Assert.ThrowsAsync<TaskCanceledException>(async () => await downloadTask);
+        var result = await downloadTask;
+        Assert.True(string.IsNullOrEmpty(result) || File.Exists(result));
         Assert.False(_tracker.ShouldSkipDownload(appId, "english"));
         Assert.False(_tracker.ShouldSkipDownload(appId, "german"));
     }


### PR DESCRIPTION
## Summary
- avoid rethrowing cancellations in GameImageCache.DownloadAsync and only log unexpected ones
- swallow cancelled image requests in SharedImageService and return a fallback path
- cover cancellation scenarios with tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68abe57cf62c8330b0eabcdd511e2419