### PR TITLE
Propagate cancellation in rate limiter

### DIFF
--- a/CommonUtilities.Tests/DomainRateLimiterTests.cs
+++ b/CommonUtilities.Tests/DomainRateLimiterTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonUtilities;
+using Xunit;
+
+public class DomainRateLimiterTests
+{
+    [Fact]
+    public async Task WaitAsync_Cancellation_ReleasesSemaphore()
+    {
+        var type = typeof(GameImageCache).Assembly.GetType("CommonUtilities.DomainRateLimiter", true)!;
+        var limiter = Activator.CreateInstance(type, new object[] { 1, 60d, 1d, 60d, TimeSpan.FromMilliseconds(200), 0d })!;
+        var uri = new Uri("http://example.com");
+        var recordCall = type.GetMethod("RecordCall")!;
+        recordCall.Invoke(limiter, new object[] { uri, true, null });
+
+        var waitMethod = type.GetMethod("WaitAsync", new[] { typeof(Uri), typeof(CancellationToken) })!;
+
+        using var cts = new CancellationTokenSource(50);
+        var sw = Stopwatch.StartNew();
+        var t1 = (Task)waitMethod.Invoke(limiter, new object[] { uri, cts.Token })!;
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await t1);
+        sw.Stop();
+        Assert.InRange(sw.ElapsedMilliseconds, 0, 500);
+
+        var sw2 = Stopwatch.StartNew();
+        await (Task)waitMethod.Invoke(limiter, new object[] { uri, CancellationToken.None })!;
+        sw2.Stop();
+        Assert.InRange(sw2.ElapsedMilliseconds, 100, 500);
+
+        recordCall.Invoke(limiter, new object[] { uri, true, null });
+    }
+}

--- a/CommonUtilities/DomainRateLimiter.cs
+++ b/CommonUtilities/DomainRateLimiter.cs
@@ -50,13 +50,13 @@ namespace CommonUtilities
         /// Waits until a request is allowed for the given URI based on domain and global limits.
         /// Also enforces single concurrent request per domain.
         /// </summary>
-        public async Task WaitAsync(Uri uri)
+        public async Task WaitAsync(Uri uri, CancellationToken token)
         {
             var host = uri.Host;
 
             // First acquire domain-specific semaphore to limit concurrent requests
             var domainSemaphore = GetOrCreateDomainSemaphore(host);
-            await domainSemaphore.WaitAsync().ConfigureAwait(false);
+            await domainSemaphore.WaitAsync(token).ConfigureAwait(false);
 
             try
             {
@@ -92,7 +92,7 @@ namespace CommonUtilities
 
                     if (tokenDelay > TimeSpan.Zero)
                     {
-                        await Task.Delay(tokenDelay).ConfigureAwait(false);
+                        await Task.Delay(tokenDelay, token).ConfigureAwait(false);
                         lock (_lock)
                         {
                             RefillTokens(DateTime.UtcNow);
@@ -117,7 +117,7 @@ namespace CommonUtilities
 
                 if (domainDelay > TimeSpan.Zero)
                 {
-                    await Task.Delay(domainDelay).ConfigureAwait(false);
+                    await Task.Delay(domainDelay, token).ConfigureAwait(false);
                     lock (_lock)
                     {
                         RefillTokens(DateTime.UtcNow);

--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -331,7 +331,7 @@ namespace CommonUtilities
                 bool rateLimiterAcquired = false;
                 try
                 {
-                    await _rateLimiter.WaitAsync(uri).ConfigureAwait(false);
+                    await _rateLimiter.WaitAsync(uri, cancellationToken).ConfigureAwait(false);
                     rateLimiterAcquired = true;
                     DebugLogger.LogDebug($"Starting image download for {uri}");
                     using var response = await _http.GetAsync(uri, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- accept cancellation tokens in DomainRateLimiter.WaitAsync and use them for delays
- pass cancellation tokens from GameImageCache downloads to the rate limiter
- add unit test verifying rate limiter releases semaphore on cancellation

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68abed465a5c833096b2d787f0427b62