### PR TITLE
Use shared HttpClient across application

### DIFF
--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -483,7 +483,7 @@ namespace AnSAM
 
             var baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "AchievoLab");
 
-            using var http = new HttpClient();
+            var http = HttpClientProvider.Shared;
             var apps = await GameCacheService.RefreshAsync(baseDir, _steamClient, http);
 
             var (allGames, filteredGames) = await BuildGameListAsync(apps, null);

--- a/CommonUtilities/HttpClientProvider.cs
+++ b/CommonUtilities/HttpClientProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net.Http;
+
+namespace CommonUtilities;
+
+/// <summary>
+/// Provides a shared <see cref="HttpClient"/> instance for the entire application.
+/// </summary>
+public static class HttpClientProvider
+{
+    private static readonly Lazy<HttpClient> _client = new(() =>
+    {
+        var http = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        if (!http.DefaultRequestHeaders.Contains("User-Agent"))
+        {
+            http.DefaultRequestHeaders.Add("User-Agent", "AchievoLab/1.0");
+        }
+        return http;
+    });
+
+    /// <summary>
+    /// Gets the shared <see cref="HttpClient"/> instance.
+    /// </summary>
+    public static HttpClient Shared => _client.Value;
+}
+

--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -20,7 +20,7 @@ namespace MyOwnGames
         private bool _disposed;
 
         public SteamApiService(string apiKey)
-            : this(apiKey, new HttpClient(), true, null)
+            : this(apiKey, HttpClientProvider.Shared, false, null)
         {
         }
 
@@ -31,10 +31,14 @@ namespace MyOwnGames
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _disposeHttpClient = disposeHttpClient;
             _rateLimiter = rateLimiter ?? RateLimiterService.FromAppSettings();
-            _httpClient.Timeout = TimeSpan.FromSeconds(30);
-            if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
+
+            if (_disposeHttpClient)
             {
-                _httpClient.DefaultRequestHeaders.Add("User-Agent", "MyOwnGames/1.0");
+                _httpClient.Timeout = TimeSpan.FromSeconds(30);
+                if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
+                {
+                    _httpClient.DefaultRequestHeaders.Add("User-Agent", "MyOwnGames/1.0");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add `HttpClientProvider` to supply a shared `HttpClient`
- refactor cache and image services to reuse shared client and allow injection
- update Steam API service and main window to utilize the shared client
- adjust tests for injectable clients

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68abf01243388330b2a09d35ce9f377c