### PR TITLE
Avoid long waits when switching image language

### DIFF
--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -51,14 +51,8 @@ namespace CommonUtilities
 
                 // Capture pending requests before clearing
                 var pending = _pendingRequests.Values.ToArray();
-                try
-                {
-                    await Task.WhenAll(pending).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Swallow exceptions from pending tasks
-                }
+                // Don't block waiting for all requests to finish
+                _ = Task.WhenAll(pending); // 背景等待
 
                 // Now clear caches and reset state
                 _imageCache.Clear();


### PR DESCRIPTION
## Summary
- stop awaiting pending image downloads when changing languages
- keep cache clearing and language state updates intact

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68abf9b64a508330846800930dd7327b