### PR TITLE
Cap domain rate limiter delay

### DIFF
--- a/CommonUtilities.Tests/DomainRateLimiterTests.cs
+++ b/CommonUtilities.Tests/DomainRateLimiterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,5 +58,30 @@ public class DomainRateLimiterTests
 
         var recordCall = type.GetMethod("RecordCall")!;
         recordCall.Invoke(limiter, new object[] { uri, true, null });
+    }
+
+    [Fact]
+    public void RecordCall_DelayDoesNotExceedCap()
+    {
+        var type = typeof(GameImageCache).Assembly.GetType("CommonUtilities.DomainRateLimiter", true)!;
+        var limiter = Activator.CreateInstance(type, new object[] { 1, 60d, 1d, 60d, TimeSpan.FromSeconds(1), 0d })!;
+        var uri = new Uri("http://example.com");
+        var recordCall = type.GetMethod("RecordCall")!;
+
+        for (int i = 0; i < 5; i++)
+        {
+            recordCall.Invoke(limiter, new object[] { uri, false, null });
+        }
+
+        var field = type.GetField("_domainExtraDelay", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var dict = (Dictionary<string, TimeSpan>)field.GetValue(limiter)!;
+        Assert.True(dict.TryGetValue(uri.Host, out var delay));
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
+
+        recordCall.Invoke(limiter, new object[] { uri, false, TimeSpan.FromSeconds(60) });
+
+        dict = (Dictionary<string, TimeSpan>)field.GetValue(limiter)!;
+        Assert.True(dict.TryGetValue(uri.Host, out delay));
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
     }
 }

--- a/CommonUtilities/DomainRateLimiter.cs
+++ b/CommonUtilities/DomainRateLimiter.cs
@@ -173,6 +173,13 @@ namespace CommonUtilities
                     {
                         computed = serverDelay.Value;
                     }
+
+                    var cap = TimeSpan.FromSeconds(30);
+                    if (computed > cap)
+                    {
+                        computed = cap;
+                    }
+
                     _domainExtraDelay[host] = computed;
                 }
 


### PR DESCRIPTION
## Summary
- prevent DomainRateLimiter from accumulating more than 30s extra delay per host
- add unit test ensuring delay cap is enforced

## Testing
- `dotnet test`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj --filter RecordCall_DelayDoesNotExceedCap -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68abff7da79c83309c16cbe9d310c187