### PR TITLE
Avoid extra English fallbacks for logo downloads

### DIFF
--- a/CommonUtilities/GameImageCache.cs
+++ b/CommonUtilities/GameImageCache.cs
@@ -186,7 +186,7 @@ namespace CommonUtilities
             });
         }
 
-        public async Task<ImageResult?> GetImagePathAsync(string cacheKey, IEnumerable<string> uris, string language = "english", int? failureId = null, CancellationToken cancellationToken = default)
+        public async Task<ImageResult?> GetImagePathAsync(string cacheKey, IEnumerable<string> uris, string language = "english", int? failureId = null, CancellationToken cancellationToken = default, bool tryEnglishFallback = true)
         {
             int notFoundCount = 0;
             var totalUrls = uris.Count();
@@ -208,7 +208,7 @@ namespace CommonUtilities
                         DebugLogger.LogDebug($"404 count for {cacheKey} in {language}: {notFoundCount}/{totalUrls}");
 
                         // After 2 CDN failures, try English fallback if we're not already on English
-                        if (notFoundCount >= 2 && !string.Equals(language, "english", StringComparison.OrdinalIgnoreCase))
+                        if (tryEnglishFallback && notFoundCount >= 2 && !string.Equals(language, "english", StringComparison.OrdinalIgnoreCase))
                         {
                             DebugLogger.LogDebug($"Switching to English fallback for {cacheKey} after {notFoundCount} 404s");
                             var fallback = await TryEnglishFallbackAsync(cacheKey, language, failureId, cancellationToken).ConfigureAwait(false);

--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -229,7 +229,7 @@ namespace CommonUtilities
             AddUrl(logoUrlMap, $"https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/{appId}/logo.png");
 
             var logoUrls = RoundRobin(logoUrlMap);
-            result = await _cache.GetImagePathAsync(appId.ToString(), logoUrls, originalLanguage, appId, _cts.Token);
+            result = await _cache.GetImagePathAsync(appId.ToString(), logoUrls, originalLanguage, appId, _cts.Token, tryEnglishFallback: false);
             if (!string.IsNullOrEmpty(result?.Path) && IsFreshImage(result.Value.Path))
             {
                 _imageCache[cacheKey] = result.Value.Path;


### PR DESCRIPTION
## Summary
- add optional flag to skip English fallbacks in GameImageCache
- bypass English fallback when fetching logo images

## Testing
- `dotnet test`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: RecordsFailureFor404sAndSkipsFurtherRequests, ConsecutiveForbiddenIncreasesDelay)*

------
https://chatgpt.com/codex/tasks/task_e_68ac120b1e808330aa8d657d4df35fc3