### PR TITLE
Add Steam-specific rate limiter and jitter tests

### DIFF
--- a/AnSAM.Tests/RateLimiterServiceTests.cs
+++ b/AnSAM.Tests/RateLimiterServiceTests.cs
@@ -33,5 +33,48 @@ namespace AnSAM.Tests
             Assert.True(results[1] >= TimeSpan.FromSeconds(1.5));
             Assert.True(results[2] >= TimeSpan.FromSeconds(3.0));
         }
+
+        [Fact]
+        public async Task WaitAsync_UsesConfiguredJitterRange()
+        {
+            var options = new RateLimiterOptions
+            {
+                MaxCallsPerMinute = 100,
+                JitterMinSeconds = 5,
+                JitterMaxSeconds = 6
+            };
+            using var rateLimiter = new RateLimiterService(options);
+
+            await rateLimiter.WaitAsync();
+            var stopwatch = Stopwatch.StartNew();
+            await rateLimiter.WaitAsync();
+            var elapsed = stopwatch.Elapsed;
+
+            Assert.True(elapsed >= TimeSpan.FromSeconds(5));
+            Assert.True(elapsed <= TimeSpan.FromSeconds(7));
+        }
+
+        [Fact]
+        public async Task WaitSteamAsync_UsesSteamJitterRange()
+        {
+            var options = new RateLimiterOptions
+            {
+                MaxCallsPerMinute = 100,
+                JitterMinSeconds = 5,
+                JitterMaxSeconds = 6,
+                SteamMaxCallsPerMinute = 100,
+                SteamJitterMinSeconds = 5.5,
+                SteamJitterMaxSeconds = 6.5
+            };
+            using var rateLimiter = new RateLimiterService(options);
+
+            await rateLimiter.WaitSteamAsync();
+            var stopwatch = Stopwatch.StartNew();
+            await rateLimiter.WaitSteamAsync();
+            var elapsed = stopwatch.Elapsed;
+
+            Assert.True(elapsed >= TimeSpan.FromSeconds(5.5));
+            Assert.True(elapsed <= TimeSpan.FromSeconds(7.5));
+        }
     }
 }

--- a/MyOwnGames/Services/RateLimiterService.cs
+++ b/MyOwnGames/Services/RateLimiterService.cs
@@ -23,6 +23,12 @@ namespace MyOwnGames.Services
         private readonly double _maxDelaySeconds;
         private readonly SemaphoreSlim _semaphore = new(1, 1);
         private DateTime _lastCall = DateTime.MinValue;
+
+        private readonly TokenBucketRateLimiter _steamLimiter;
+        private readonly double _steamMinDelaySeconds;
+        private readonly double _steamMaxDelaySeconds;
+        private readonly SemaphoreSlim _steamSemaphore = new(1, 1);
+        private DateTime _steamLastCall = DateTime.MinValue;
         private bool _disposed;
 
         public RateLimiterService(RateLimiterOptions options)
@@ -33,8 +39,16 @@ namespace MyOwnGames.Services
                 options.JitterMaxSeconds = options.JitterMinSeconds;
             }
 
+            options.SteamJitterMinSeconds = Math.Max(5.0, options.SteamJitterMinSeconds);
+            if (options.SteamJitterMaxSeconds < options.SteamJitterMinSeconds)
+            {
+                options.SteamJitterMaxSeconds = options.SteamJitterMinSeconds;
+            }
+
             _minDelaySeconds = options.JitterMinSeconds;
             _maxDelaySeconds = options.JitterMaxSeconds;
+            _steamMinDelaySeconds = options.SteamJitterMinSeconds;
+            _steamMaxDelaySeconds = options.SteamJitterMaxSeconds;
 
             _limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -44,6 +58,16 @@ namespace MyOwnGames.Services
                 AutoReplenishment = true,
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = options.MaxCallsPerMinute
+            });
+
+            _steamLimiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = options.SteamMaxCallsPerMinute,
+                TokensPerPeriod = options.SteamMaxCallsPerMinute,
+                ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                AutoReplenishment = true,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = options.SteamMaxCallsPerMinute
             });
         }
 
@@ -94,6 +118,34 @@ namespace MyOwnGames.Services
             }
         }
 
+        public async Task WaitSteamAsync(CancellationToken cancellationToken = default)
+        {
+            var lease = await _steamLimiter.AcquireAsync(1, cancellationToken);
+            if (!lease.IsAcquired)
+            {
+                throw new InvalidOperationException("Unable to acquire rate limiter lease.");
+            }
+
+            await _steamSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var now = DateTime.UtcNow;
+                var elapsed = now - _steamLastCall;
+                var jitterSeconds = _steamMinDelaySeconds + Random.Shared.NextDouble() * (_steamMaxDelaySeconds - _steamMinDelaySeconds);
+                var delay = TimeSpan.FromSeconds(jitterSeconds);
+                if (elapsed < delay)
+                {
+                    await Task.Delay(delay - elapsed, cancellationToken);
+                }
+                _steamLastCall = DateTime.UtcNow;
+            }
+            finally
+            {
+                _steamSemaphore.Release();
+                lease.Dispose();
+            }
+        }
+
         public void Dispose()
         {
             if (_disposed)
@@ -101,7 +153,9 @@ namespace MyOwnGames.Services
                 return;
             }
             _limiter.Dispose();
+            _steamLimiter.Dispose();
             _semaphore.Dispose();
+            _steamSemaphore.Dispose();
             _disposed = true;
         }
     }


### PR DESCRIPTION
## Summary
- expose dedicated Steam token bucket rate limiter with its own jitter configuration
- add WaitSteamAsync to use Steam-specific limiter and delay
- test generic and Steam jitter ranges

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5804835883309b2edf21e78569c9