### PR TITLE
Add Steam-specific rate limiter configuration

### DIFF
--- a/MyOwnGames.Tests/RateLimiterConfigTests.cs
+++ b/MyOwnGames.Tests/RateLimiterConfigTests.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using MyOwnGames.Services;
+using Xunit;
+
+public class RateLimiterConfigTests
+{
+    [Fact]
+    public void BindsSteamSpecificValues()
+    {
+        var json = """
+        {
+          "RateLimiter": {
+            "SteamMaxCallsPerMinute": 15,
+            "SteamJitterMinSeconds": 6.5,
+            "SteamJitterMaxSeconds": 7.5
+          }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+
+        var options = new RateLimiterOptions();
+        config.GetSection("RateLimiter").Bind(options);
+
+        Assert.Equal(15, options.SteamMaxCallsPerMinute);
+        Assert.Equal(6.5, options.SteamJitterMinSeconds);
+        Assert.Equal(7.5, options.SteamJitterMaxSeconds);
+    }
+}

--- a/MyOwnGames/appsettings.json
+++ b/MyOwnGames/appsettings.json
@@ -2,6 +2,9 @@
   "RateLimiter": {
     "MaxCallsPerMinute": 30,
     "JitterMinSeconds": 1.5,
-    "JitterMaxSeconds": 3.0
+    "JitterMaxSeconds": 3.0,
+    "SteamMaxCallsPerMinute": 12,
+    "SteamJitterMinSeconds": 5.5,
+    "SteamJitterMaxSeconds": 7.5
   }
 }

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ winget install Microsoft.DotNet.DesktopRuntime.8 Microsoft.WindowsAppSDK.1.7
    The main GUI interface.
 2. **./RunGame/RunGame.exe**  
    Invoked by *AnASM.exe* when a game cover is double-clicked. Used to manage achievements for the selected game.
-3. **./MyOwnGames/MyOwnGames.exe**  
-   Retrieves your owned game data from the Steam Web API.  
+3. **./MyOwnGames/MyOwnGames.exe**
+   Retrieves your owned game data from the Steam Web API.
    ⚠️ Note: This process may take some time. The Steam API may temporarily block your key if requests are made too frequently.
 
 ## Using *MyOwnGames*
@@ -44,6 +44,25 @@ winget install Microsoft.DotNet.DesktopRuntime.8 Microsoft.WindowsAppSDK.1.7
 4. Your 17-digit SteamID64 will be shown near the top of the page, below your username.  
 
 > If this method no longer works, please look up an updated way to obtain your SteamID64.
+
+### Tuning Steam API throttling
+
+`MyOwnGames` throttles its Steam Web API requests to avoid hitting rate limits. You can adjust these limits in `MyOwnGames/appsettings.json`:
+
+```json
+{
+  "RateLimiter": {
+    "MaxCallsPerMinute": 30,
+    "JitterMinSeconds": 1.5,
+    "JitterMaxSeconds": 3.0,
+    "SteamMaxCallsPerMinute": 12,
+    "SteamJitterMinSeconds": 5.5,
+    "SteamJitterMaxSeconds": 7.5
+  }
+}
+```
+
+The `SteamMaxCallsPerMinute` and `SteamJitter*` values let you tune Steam-specific throttling separately from the general settings.
 
 ## License
 This project is licensed under the [MIT License](LICENSE).  


### PR DESCRIPTION
## Summary
- add Steam-specific throttle settings in `appsettings.json`
- document Steam Web API rate limit options in the README
- test binding of new Steam configuration values

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5d3aec5483309c5c80022ef6e023