### PR TITLE
Query disk image cache before network fetch

### DIFF
--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -133,6 +133,21 @@ namespace CommonUtilities
                 // Don't record as failed download - file was corrupted, not missing
             }
 
+            // Check the on-disk cache before making any network calls
+            var diskCachedPath = _cache.TryGetCachedPath(appId.ToString(), language, checkEnglishFallback: false);
+            if (!string.IsNullOrEmpty(diskCachedPath))
+            {
+                if (IsFreshImage(diskCachedPath))
+                {
+                    _imageCache[cacheKey] = diskCachedPath;
+                    TriggerImageDownloadCompletedEvent(appId, diskCachedPath);
+                    return diskCachedPath;
+                }
+
+                try { File.Delete(diskCachedPath); } catch { }
+                // Don't record as failed download - file was corrupted or expired
+            }
+
             var languageSpecificUrlMap = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
             static void AddUrl(Dictionary<string, List<string>> map, string url)


### PR DESCRIPTION
## Summary
- Check disk cache in SharedImageService before reaching out to the network

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: GameImageCacheTests.RecordsFailureFor404sAndSkipsFurtherRequests, GameImageCacheTests.ConsecutiveForbiddenIncreasesDelay)*

------
https://chatgpt.com/codex/tasks/task_e_68ac648c811c8330b94527f3076cfaf7