### PR TITLE
Ensure hidden images reload after language switch

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -1284,12 +1284,17 @@ namespace MyOwnGames
 
                 AppendLog($"Found {visibleItems.Count} visible games, {hiddenItems.Count} hidden games");
 
-                // 2. 清空所有隱藏項目的圖片（設置為預設圖片）
+                // 2. 清空所有隱藏項目的圖片（設置為預設圖片）並移除成功載入記錄
                 this.DispatcherQueue.TryEnqueue(() =>
                 {
                     foreach (var hiddenItem in hiddenItems)
                     {
                         hiddenItem.IconUri = "ms-appx:///Assets/no_icon.png";
+                        var key = $"{hiddenItem.AppId}_{newLanguage}";
+                        lock (_imageLoadingLock)
+                        {
+                            _imagesSuccessfullyLoaded.Remove(key);
+                        }
                     }
                 });
 


### PR DESCRIPTION
## Summary
- Remove hidden game entries from `_imagesSuccessfullyLoaded` when switching languages so their icons reload when scrolled into view
- Guard set modifications with `_imageLoadingLock` for thread safety

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68ad27333c1c83308aa13a6c727f9bd2