### PR TITLE
Use dedicated HttpClient for image downloads

### DIFF
--- a/AnSAM.Tests/GameCacheServiceTests.cs
+++ b/AnSAM.Tests/GameCacheServiceTests.cs
@@ -101,7 +101,7 @@ public class GameCacheServiceTests
             var pngData = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
             File.WriteAllBytes(cachedImagePath, pngData);
 
-            var service = new SharedImageService();
+            var service = new SharedImageService(new HttpClient(), disposeHttpClient: true);
             var path = await service.GetGameImageAsync(570);
             Assert.Equal(cachedImagePath, path);
             service.Dispose();

--- a/AnSAM.Tests/GameImageServiceTests.cs
+++ b/AnSAM.Tests/GameImageServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using CommonUtilities;
@@ -18,7 +19,7 @@ public class GameImageServiceTests
         var oldTime = DateTime.Now.AddDays(-1);
         setupTracker.RecordFailedDownload(appId, "english", failedAt: oldTime);
 
-        var service = new SharedImageService();
+        var service = new SharedImageService(new HttpClient(), disposeHttpClient: true);
         var cacheField = typeof(SharedImageService).GetField("_imageCache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         var dict = (Dictionary<string, string>)cacheField!.GetValue(service)!;
         var cacheKey = $"{appId}_english";
@@ -56,7 +57,7 @@ public class GameImageServiceTests
         cleanupTracker.RemoveFailedRecord(appId, "english");
         cleanupTracker.RemoveFailedRecord(appId, "german");
 
-        var service = new SharedImageService();
+        var service = new SharedImageService(new HttpClient(), disposeHttpClient: true);
         int eventCount = 0;
         service.ImageDownloadCompleted += (_, _) => eventCount++;
 

--- a/AnSAM/MainWindow.xaml.cs
+++ b/AnSAM/MainWindow.xaml.cs
@@ -40,7 +40,8 @@ namespace AnSAM
         private readonly List<GameItem> _allGames = new();
         private readonly SteamClient _steamClient;
         private readonly AppWindow _appWindow;
-        private readonly SharedImageService _imageService = new();
+        private readonly HttpClient _imageHttpClient = new();
+        private readonly SharedImageService _imageService;
         private string _currentLanguage = "english";
 
         private bool _autoLoaded;
@@ -51,6 +52,7 @@ namespace AnSAM
         public MainWindow(SteamClient steamClient, ElementTheme theme)
         {
             _steamClient = steamClient;
+            _imageService = new SharedImageService(_imageHttpClient);
             InitializeComponent();
 
             _uiSettings.ColorValuesChanged += UiSettings_ColorValuesChanged;
@@ -368,6 +370,7 @@ namespace AnSAM
             _uiSettings.ColorValuesChanged -= UiSettings_ColorValuesChanged;
             Activated -= OnWindowActivated;
             _imageService.Dispose();
+            _imageHttpClient.Dispose();
 
             if (Content is FrameworkElement root)
             {

--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -25,10 +25,10 @@ namespace CommonUtilities
 
         public event Action<int, string?>? ImageDownloadCompleted;
 
-        public SharedImageService(HttpClient? httpClient = null, GameImageCache? cache = null, bool disposeHttpClient = false)
+        public SharedImageService(HttpClient httpClient, GameImageCache? cache = null, bool disposeHttpClient = false)
         {
-            _httpClient = httpClient ?? HttpClientProvider.Shared;
-            _disposeHttpClient = disposeHttpClient && httpClient != null;
+            _httpClient = httpClient;
+            _disposeHttpClient = disposeHttpClient;
 
             if (cache != null)
             {

--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
@@ -41,7 +42,8 @@ namespace MyOwnGames
         public ObservableCollection<GameEntry> GameItems { get; } = new();
         private List<GameEntry> AllGameItems { get; } = new();
         public ObservableCollection<string> LogEntries { get; } = new();
-        private readonly SharedImageService _imageService = new();
+        private readonly HttpClient _imageHttpClient = new();
+        private readonly SharedImageService _imageService;
         private readonly GameDataService _dataService = new();
         private readonly Action<string> _logHandler;
         private SteamApiService? _steamService;
@@ -221,6 +223,7 @@ namespace MyOwnGames
         }
         public MainWindow()
         {
+            _imageService = new SharedImageService(_imageHttpClient);
             InitializeComponent();
             this.ExtendsContentIntoTitleBar = true;
             this.AppWindow.Title = "My Own Steam Games";
@@ -1159,6 +1162,7 @@ namespace MyOwnGames
                     _imageService.ImageDownloadCompleted -= OnImageDownloadCompleted;
                     _imageService.Dispose();
                 }
+                _imageHttpClient.Dispose();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Require an `HttpClient` instance when constructing `SharedImageService`
- Create and dispose a dedicated image `HttpClient` in AnSAM and MyOwnGames windows
- Update tests for the new `SharedImageService` constructor

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3e51daec8330b09a04c94c1962ba