### PR TITLE
Defer game image loading until item appears

### DIFF
--- a/MyOwnGames/MainWindow.xaml
+++ b/MyOwnGames/MainWindow.xaml
@@ -136,6 +136,7 @@
                   IsItemClickEnabled="False"
                   IsTabStop="False"
                   DoubleTapped="GamesGridView_DoubleTapped"
+                  ContainerContentChanging="GamesGridView_ContainerContentChanging"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   ScrollViewer.HorizontalScrollMode="Disabled">
             


### PR DESCRIPTION
## Summary
- delay game image downloads until their tiles are realized
- load images on demand using GridView.ContainerContentChanging with cache-aware logic

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad402cb5f0833090c7152215c665bb