### PR TITLE
Refactor SetLanguage to return completed task

### DIFF
--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -42,7 +42,7 @@ namespace CommonUtilities
             }
         }
 
-        public async Task SetLanguage(string language)
+        public Task SetLanguage(string language)
         {
             if (_currentLanguage != language)
             {
@@ -66,6 +66,7 @@ namespace CommonUtilities
                 _cts = new CancellationTokenSource();
                 _currentLanguage = language;
             }
+            return Task.CompletedTask;
         }
 
         public string GetCurrentLanguage() => _currentLanguage;


### PR DESCRIPTION
## Summary
- refactor SharedImageService.SetLanguage to return `Task.CompletedTask`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6052728c8330b459fef953704b70