### PR TITLE
Assert not null before verifying cached game IDs

### DIFF
--- a/AnSAM.Tests/GameCacheServiceTests.cs
+++ b/AnSAM.Tests/GameCacheServiceTests.cs
@@ -89,7 +89,8 @@ public class GameCacheServiceTests
             var userGamesPath = Path.Combine(cacheDir, "usergames.xml");
             var doc = XDocument.Load(userGamesPath);
             var ids = doc.Root?.Elements("game").Select(g => (int?)g.Attribute("id")).Where(i => i.HasValue).Select(i => i!.Value).ToArray();
-            Assert.Contains(570, ids);
+            Assert.NotNull(ids);
+            Assert.Contains(570, ids!);
 
             var tracker = new ImageFailureTrackingService();
             tracker.RemoveFailedRecord(570, "english");


### PR DESCRIPTION
## Summary
- ensure cached game ID array is non-null before validation in `SteamGamesXmlIdsAreProcessedAndImagesRetrieved` test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6053c3808330bd5feb17dcf09c30