### PR TITLE
test: ensure rate limiter delay key presence

### DIFF
--- a/CommonUtilities.Tests/GameImageCacheTests.cs
+++ b/CommonUtilities.Tests/GameImageCacheTests.cs
@@ -627,11 +627,15 @@ public class GameImageCacheTests : IDisposable
         var rateLimiter = rateLimiterField.GetValue(cache)!;
         var extraField = rateLimiter.GetType().GetField("_domainExtraDelay", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var dict = (System.Collections.IDictionary)extraField.GetValue(rateLimiter)!;
-        Assert.True(((TimeSpan)dict[uri.Host]) >= TimeSpan.FromMilliseconds(100));
+        Assert.True(dict.Contains(uri.Host));
+        var delay = (TimeSpan)dict[uri.Host]!;
+        Assert.True(delay >= TimeSpan.FromMilliseconds(100));
 
         await cache.GetImagePathAsync("b", uri, "english");
         dict = (System.Collections.IDictionary)extraField.GetValue(rateLimiter)!;
-        Assert.True(((TimeSpan)dict[uri.Host]) >= TimeSpan.FromMilliseconds(200));
+        Assert.True(dict.Contains(uri.Host));
+        delay = (TimeSpan)dict[uri.Host]!;
+        Assert.True(delay >= TimeSpan.FromMilliseconds(200));
 
         var sw = Stopwatch.StartNew();
         await cache.GetImagePathAsync("c", uri, "english");


### PR DESCRIPTION
## Summary
- validate domain delay keys in rate limiter before casting
- reuse delay variable for assertions

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: Assert.True() Failure in RecordsFailureFor404sAndSkipsFurtherRequests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6060497c83308a6338c471801666