### PR TITLE
Use Get instead of Bind in rate limiter service

### DIFF
--- a/MyOwnGames/Services/RateLimiterService.cs
+++ b/MyOwnGames/Services/RateLimiterService.cs
@@ -81,7 +81,8 @@ namespace MyOwnGames.Services
                     .AddEnvironmentVariables()
                     .Build();
                 var section = config.GetSection("RateLimiter");
-                section.Bind(options);
+                var bound = section.Get<RateLimiterOptions>();
+                if (bound != null) options = bound;
             }
             catch
             {


### PR DESCRIPTION
## Summary
- Avoid potential null configuration binding by replacing `Bind` with `Get` when loading rate limiter options
- Ensure configuration namespace is referenced

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ad606ec07c83309f94b735bb8576a4