### PR TITLE
Check RequestUri for null in Steam fallback handler

### DIFF
--- a/CommonUtilities.Tests/GameImageCacheTests.cs
+++ b/CommonUtilities.Tests/GameImageCacheTests.cs
@@ -794,7 +794,7 @@ public class GameImageCacheTests : IDisposable
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (request.RequestUri.Host.EndsWith("steamstatic.com", StringComparison.OrdinalIgnoreCase))
+            if (request.RequestUri != null && request.RequestUri.Host.EndsWith("steamstatic.com", StringComparison.OrdinalIgnoreCase))
             {
                 var data = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0, 0, 0, 0 };
                 var response = new HttpResponseMessage(HttpStatusCode.OK)


### PR DESCRIPTION
## Summary
- Ensure `SteamFallbackHandler` verifies `RequestUri` is non-null before host comparison

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: Failed: 1, Passed: 33)*

------
https://chatgpt.com/codex/tasks/task_e_68ad606560e083309d975e6487ad0abe