### PR TITLE
Use shared JsonSerializer options

### DIFF
--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Linq;
 
 namespace CommonUtilities
@@ -22,6 +23,12 @@ namespace CommonUtilities
         private readonly object _eventLock = new();
         private CancellationTokenSource _cts = new();
         private string _currentLanguage = "english";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        };
 
         public event Action<int, string?>? ImageDownloadCompleted;
 
@@ -281,8 +288,7 @@ namespace CommonUtilities
                 }
 
                 var jsonContent = await response.Content.ReadAsStringAsync();
-                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                var storeData = JsonSerializer.Deserialize<Dictionary<string, StoreApiResponse>>(jsonContent, options);
+                var storeData = JsonSerializer.Deserialize<Dictionary<string, StoreApiResponse>>(jsonContent, JsonOptions);
 
                 if (storeData != null && storeData.TryGetValue(appId.ToString(), out var app) && app.Success)
                 {

--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
@@ -19,6 +20,12 @@ namespace MyOwnGames
         private readonly RateLimiterService _steamRateLimiter;
         private readonly bool _disposeHttpClient;
         private bool _disposed;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        };
 
         public SteamApiService(string apiKey)
             : this(apiKey, HttpClientProvider.Shared, false, null, null)
@@ -196,13 +203,13 @@ namespace MyOwnGames
         [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The types used in JSON deserialization are explicitly referenced and won't be trimmed")]
         private static OwnedGamesResponse? DeserializeOwnedGamesResponse(string json)
         {
-            return JsonSerializer.Deserialize<OwnedGamesResponse>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return JsonSerializer.Deserialize<OwnedGamesResponse>(json, JsonOptions);
         }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The types used in JSON deserialization are explicitly referenced and won't be trimmed")]
         private static Dictionary<string, AppDetailsResponse>? DeserializeAppDetailsResponse(string json)
         {
-            return JsonSerializer.Deserialize<Dictionary<string, AppDetailsResponse>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return JsonSerializer.Deserialize<Dictionary<string, AppDetailsResponse>>(json, JsonOptions);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- add resolver-enabled `JsonSerializerOptions` in Steam API service
- reuse the same options in shared image service to enable trimming-friendly JSON

## Testing
- `dotnet test -c Release` *(fails: GameImageCacheTests.RecordsFailureFor404sAndSkipsFurtherRequests)*
- `dotnet publish MyOwnGames/MyOwnGames.csproj -c Release -o /tmp/publish` *(fails: XamlCompiler exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62fef9948330ba742ca4645f48de