### PR TITLE
Check Steam service before English game update

### DIFF
--- a/MyOwnGames/MainWindow.xaml.cs
+++ b/MyOwnGames/MainWindow.xaml.cs
@@ -704,8 +704,9 @@ namespace MyOwnGames
                 {
                     AppendLog($"Found {gamesMissingEnglishNames.Count} games missing English names. Forcing English data update first...");
                     StatusText = "First updating English game names (required for localization)...";
-                    
+
                     // Force English update first
+                    ArgumentNullException.ThrowIfNull(_steamService);
                     var englishTotal = await _steamService.GetOwnedGamesAsync(steamId64!, "english", async englishGame =>
                     {
                         // Always update English data for games missing it


### PR DESCRIPTION
## Summary
- Guard Steam service against null before updating English game names

## Testing
- `dotnet build MyOwnGames/MyOwnGames.csproj -c Release` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6841d5908330b9f233188d22e5e9