### PR TITLE
Use source-generated JSON context

### DIFF
--- a/AnSAM.Tests/AnSAM.Tests.csproj
+++ b/AnSAM.Tests/AnSAM.Tests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="../MyOwnGames/InputValidator.cs" Link="InputValidator.cs" />
     <Compile Include="../MyOwnGames/SteamApiService.cs" Link="SteamApiService.cs" />
     <Compile Include="../MyOwnGames/Services/RateLimiterService.cs" Link="RateLimiterService.cs" />
+    <Compile Include="../MyOwnGames/SteamApiJsonContext.cs" Link="SteamApiJsonContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 using System.Linq;
 
 namespace CommonUtilities
@@ -24,11 +23,8 @@ namespace CommonUtilities
         private CancellationTokenSource _cts = new();
         private string _currentLanguage = "english";
 
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNameCaseInsensitive = true,
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
-        };
+        private static readonly JsonSerializerOptions JsonOptions =
+            new() { TypeInfoResolver = StoreApiJsonContext.Default };
 
         public event Action<int, string?>? ImageDownloadCompleted;
 
@@ -288,7 +284,7 @@ namespace CommonUtilities
                 }
 
                 var jsonContent = await response.Content.ReadAsStringAsync();
-                var storeData = JsonSerializer.Deserialize<Dictionary<string, StoreApiResponse>>(jsonContent, JsonOptions);
+                var storeData = JsonSerializer.Deserialize(jsonContent, StoreApiJsonContext.Default.DictionaryStringStoreApiResponse);
 
                 if (storeData != null && storeData.TryGetValue(appId.ToString(), out var app) && app.Success)
                 {
@@ -393,7 +389,10 @@ namespace CommonUtilities
 
     internal class StoreApiResponse
     {
+        [JsonPropertyName("success")]
         public bool Success { get; set; }
+
+        [JsonPropertyName("data")]
         public StoreApiData? Data { get; set; }
     }
 

--- a/CommonUtilities/StoreApiJsonContext.cs
+++ b/CommonUtilities/StoreApiJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace CommonUtilities;
+
+[JsonSerializable(typeof(Dictionary<string, StoreApiResponse>))]
+internal partial class StoreApiJsonContext : JsonSerializerContext
+{
+}
+

--- a/MyOwnGames.Tests/MyOwnGames.Tests.csproj
+++ b/MyOwnGames.Tests/MyOwnGames.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="../MyOwnGames/SteamApiService.cs" Link="SteamApiService.cs" />
     <Compile Include="../MyOwnGames/Services/RateLimiterService.cs" Link="RateLimiterService.cs" />
     <Compile Include="../MyOwnGames/InputValidator.cs" Link="InputValidator.cs" />
+    <Compile Include="../MyOwnGames/SteamApiJsonContext.cs" Link="SteamApiJsonContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/MyOwnGames/SteamApiJsonContext.cs
+++ b/MyOwnGames/SteamApiJsonContext.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MyOwnGames;
+
+[JsonSerializable(typeof(OwnedGamesResponse))]
+[JsonSerializable(typeof(Dictionary<string, AppDetailsResponse>))]
+internal partial class SteamApiJsonContext : JsonSerializerContext
+{
+}
+

--- a/MyOwnGames/SteamApiService.cs
+++ b/MyOwnGames/SteamApiService.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
@@ -21,11 +20,8 @@ namespace MyOwnGames
         private readonly bool _disposeHttpClient;
         private bool _disposed;
 
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            PropertyNameCaseInsensitive = true,
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
-        };
+        private static readonly JsonSerializerOptions JsonOptions =
+            new() { TypeInfoResolver = SteamApiJsonContext.Default };
 
         public SteamApiService(string apiKey)
             : this(apiKey, HttpClientProvider.Shared, false, null, null)
@@ -200,16 +196,14 @@ namespace MyOwnGames
             return $"https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/{appId}/header_{language}.jpg";
         }
 
-        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The types used in JSON deserialization are explicitly referenced and won't be trimmed")]
         private static OwnedGamesResponse? DeserializeOwnedGamesResponse(string json)
         {
-            return JsonSerializer.Deserialize<OwnedGamesResponse>(json, JsonOptions);
+            return JsonSerializer.Deserialize(json, SteamApiJsonContext.Default.OwnedGamesResponse);
         }
 
-        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The types used in JSON deserialization are explicitly referenced and won't be trimmed")]
         private static Dictionary<string, AppDetailsResponse>? DeserializeAppDetailsResponse(string json)
         {
-            return JsonSerializer.Deserialize<Dictionary<string, AppDetailsResponse>>(json, JsonOptions);
+            return JsonSerializer.Deserialize(json, SteamApiJsonContext.Default.DictionaryStringAppDetailsResponse);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- Generate source context for Steam API and store image API JSON models
- Replace custom `JsonSerializerOptions` with context-based resolvers
- Switch deserialization to context-aware overloads and map store API property names

## Testing
- `dotnet test`
- `dotnet build CommonUtilities/CommonUtilities.csproj -p:EnableTrimAnalyzer=true`
- ⚠️ `dotnet publish MyOwnGames/MyOwnGames.csproj -c Release` *(fails: XamlCompiler.exe exec format error)*


------
https://chatgpt.com/codex/tasks/task_e_68ad68431ce48330ad27fe6beb5adacc