### PR TITLE
Use explicit binding for rate limiter options

### DIFF
--- a/MyOwnGames/Services/RateLimiterService.cs
+++ b/MyOwnGames/Services/RateLimiterService.cs
@@ -81,8 +81,9 @@ namespace MyOwnGames.Services
                     .AddEnvironmentVariables()
                     .Build();
                 var section = config.GetSection("RateLimiter");
-                var bound = section.Get<RateLimiterOptions>();
-                if (bound != null) options = bound;
+                var bound = new RateLimiterOptions();
+                section.Bind(bound);
+                options = bound;
             }
             catch
             {


### PR DESCRIPTION
## Summary
- bind rate limiter options without reflection

## Testing
- `dotnet test`
- `dotnet publish MyOwnGames/MyOwnGames.csproj -c Release -o /tmp/mogpublish` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6843be348330aeaa127f5a1ddc30