### PR TITLE
Use strongly typed config binding for rate limiter

### DIFF
--- a/MyOwnGames/Services/RateLimiterService.cs
+++ b/MyOwnGames/Services/RateLimiterService.cs
@@ -81,9 +81,7 @@ namespace MyOwnGames.Services
                     .AddEnvironmentVariables()
                     .Build();
                 var section = config.GetSection("RateLimiter");
-                var bound = new RateLimiterOptions();
-                section.Bind(bound);
-                options = bound;
+                options = section.Get<RateLimiterOptions>() ?? new RateLimiterOptions();
             }
             catch
             {


### PR DESCRIPTION
## Summary
- replace manual configuration binding with strongly typed Get<RateLimiterOptions> in RateLimiterService

## Testing
- `dotnet build MyOwnGames.Tests/MyOwnGames.Tests.csproj`
- `dotnet test AnSAM.Tests/AnSAM.Tests.csproj`
- `dotnet test MyOwnGames.Tests/MyOwnGames.Tests.csproj`
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj` *(fails: GameImageCacheTests.RecordsFailureFor404sAndSkipsFurtherRequests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6bfecbdc8330b350b4b5db289780