### PR TITLE
Avoid trimming warning in RateLimiterService

### DIFF
--- a/MyOwnGames/Services/RateLimiterService.cs
+++ b/MyOwnGames/Services/RateLimiterService.cs
@@ -81,7 +81,12 @@ namespace MyOwnGames.Services
                     .AddEnvironmentVariables()
                     .Build();
                 var section = config.GetSection("RateLimiter");
-                options = section.Get<RateLimiterOptions>() ?? new RateLimiterOptions();
+                options.MaxCallsPerMinute = section.GetValue<int>(nameof(RateLimiterOptions.MaxCallsPerMinute), options.MaxCallsPerMinute);
+                options.JitterMinSeconds = section.GetValue<double>(nameof(RateLimiterOptions.JitterMinSeconds), options.JitterMinSeconds);
+                options.JitterMaxSeconds = section.GetValue<double>(nameof(RateLimiterOptions.JitterMaxSeconds), options.JitterMaxSeconds);
+                options.SteamMaxCallsPerMinute = section.GetValue<int>(nameof(RateLimiterOptions.SteamMaxCallsPerMinute), options.SteamMaxCallsPerMinute);
+                options.SteamJitterMinSeconds = section.GetValue<double>(nameof(RateLimiterOptions.SteamJitterMinSeconds), options.SteamJitterMinSeconds);
+                options.SteamJitterMaxSeconds = section.GetValue<double>(nameof(RateLimiterOptions.SteamJitterMaxSeconds), options.SteamJitterMaxSeconds);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- Read `RateLimiterOptions` values individually using `GetValue` instead of `ConfigurationBinder.Get<T>` to avoid IL2026 warnings when trimming

## Testing
- `dotnet test -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68aee4554da883308d95f2c67d860cb6