### PR TITLE
Add language fallback test

### DIFF
--- a/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
+++ b/MyOwnGames.Tests/GameImageServiceLanguageTests.cs
@@ -15,6 +15,9 @@ public class GameImageServiceLanguageTests : IDisposable
     private readonly string _tempDir;
     private readonly SharedImageService _service;
     private readonly FakeImageHandler _imageHandler;
+    private readonly GameImageCache _cache;
+    private static readonly byte[] PngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfZp8AAAAASUVORK5CYII=");
 
     public GameImageServiceLanguageTests()
     {
@@ -23,10 +26,10 @@ public class GameImageServiceLanguageTests : IDisposable
 
         _imageHandler = new FakeImageHandler();
         var cacheClient = new HttpClient(_imageHandler);
-        var cache = new GameImageCache(_tempDir, new ImageFailureTrackingService(), httpClient: cacheClient, disposeHttpClient: true);
+        _cache = new GameImageCache(_tempDir, new ImageFailureTrackingService(), httpClient: cacheClient, disposeHttpClient: true);
 
         var storeClient = new HttpClient(new FakeStoreApiHandler());
-        _service = new SharedImageService(storeClient, cache, disposeHttpClient: true);
+        _service = new SharedImageService(storeClient, _cache, disposeHttpClient: true);
     }
 
     [Fact(Skip = "Flaky with configurable rate limiter")]
@@ -65,8 +68,32 @@ public class GameImageServiceLanguageTests : IDisposable
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var lang = request.RequestUri!.Query.Contains("l=german") ? "german" : "english";
-            var headerUrl = lang == "german" ? "https://example.com/header_german.jpg" : "https://example.com/header.jpg";
+            string lang;
+            if (request.RequestUri!.Query.Contains("l=german"))
+            {
+                lang = "german";
+            }
+            else if (request.RequestUri!.Query.Contains("l=tchinese"))
+            {
+                lang = "tchinese";
+            }
+            else
+            {
+                lang = "english";
+            }
+            string headerUrl;
+            if (lang == "tchinese")
+            {
+                headerUrl = "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/12345/header_tchinese.jpg";
+            }
+            else if (lang == "english")
+            {
+                headerUrl = "https://example.com/header.jpg";
+            }
+            else
+            {
+                headerUrl = $"https://example.com/header_{lang}.jpg";
+            }
             var json = $"{{\"12345\":{{\"success\":true,\"data\":{{\"header_image\":\"{headerUrl}\"}}}}}}";
             var response = new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -80,14 +107,12 @@ public class GameImageServiceLanguageTests : IDisposable
     {
         public List<string> RequestedUrls { get; } = new();
 
-        private static readonly byte[] PngBytes = Convert.FromBase64String(
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfZp8AAAAASUVORK5CYII=");
-
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var url = request.RequestUri!.AbsoluteUri;
             RequestedUrls.Add(url);
             if (url.Contains("header_german") || url.Contains("logo_german") ||
+                url.Contains("header_tchinese") || url.Contains("logo_tchinese") ||
                 url.Contains("header_english") || url.Contains("logo_english"))
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
@@ -99,5 +124,40 @@ public class GameImageServiceLanguageTests : IDisposable
             resp.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
             return Task.FromResult(resp);
         }
+    }
+
+    [Fact]
+    public async Task CopiesEnglishImage_WhenLocalizedImageMissing()
+    {
+        var appId = 12345;
+        var englishDir = Path.Combine(_tempDir, "english");
+        Directory.CreateDirectory(englishDir);
+        var englishPath = Path.Combine(englishDir, $"{appId}.png");
+        await File.WriteAllBytesAsync(englishPath, PngBytes);
+        File.SetLastWriteTimeUtc(englishPath, DateTime.UtcNow - TimeSpan.FromDays(60));
+
+        await _service.SetLanguage("tchinese");
+        // Trigger localized request (will fail and return null)
+        await _service.GetGameImageAsync(appId);
+
+        Assert.Contains(_imageHandler.RequestedUrls, url => url.Contains("header_tchinese"));
+
+        // Refresh English image so cache uses it for fallback
+        await File.WriteAllBytesAsync(englishPath, PngBytes);
+
+        var urls = new[]
+        {
+            "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/12345/header_tchinese.jpg",
+            "https://cdn.steamstatic.com/steam/apps/12345/header_tchinese.jpg"
+        };
+        var result = await _cache.GetImagePathAsync(appId.ToString(), urls, "tchinese", appId);
+
+        Assert.NotNull(result?.Path);
+        var tchineseDir = Path.Combine(_tempDir, "tchinese");
+        Assert.StartsWith(tchineseDir, result!.Value.Path);
+
+        var copiedBytes = await File.ReadAllBytesAsync(result.Value.Path);
+        var originalBytes = await File.ReadAllBytesAsync(englishPath);
+        Assert.Equal(originalBytes, copiedBytes);
     }
 }


### PR DESCRIPTION
## Summary
- add test verifying localized image requests and English fallback copy

## Testing
- `dotnet test` *(fails: Assert.NotNull() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b1627b8fd88330835f02633ae23c52