### PR TITLE
feat: add checkEnglishFallback parameter

### DIFF
--- a/CommonUtilities/SharedImageService.cs
+++ b/CommonUtilities/SharedImageService.cs
@@ -226,7 +226,7 @@ namespace CommonUtilities
             }
 
             var languageUrls = RoundRobin(languageSpecificUrlMap);
-            var result = await _cache.GetImagePathAsync(appId.ToString(), languageUrls, language, appId, _cts.Token);
+            var result = await _cache.GetImagePathAsync(appId.ToString(), languageUrls, language, appId, _cts.Token, checkEnglishFallback: false);
             if (!string.IsNullOrEmpty(result?.Path) && IsFreshImage(result.Value.Path))
             {
                 _imageCache[cacheKey] = result.Value.Path;


### PR DESCRIPTION
## Summary
- allow callers to disable English fallback when resolving image paths
- ensure SharedImageService requests localized covers before falling back

## Testing
- `dotnet test CommonUtilities.Tests/CommonUtilities.Tests.csproj --no-build -v q` *(fails: GameImageCacheTests.RecordsFailureFor404sAndSkipsFurtherRequests, GameImageCacheTests.RateLimiterDelayIsConfigurable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1626997c883309b88b6f12ffb6653