### PR TITLE
Fix missing integer stats in UserStatType enum

### DIFF
--- a/RunGame/Services/GameStatsService.cs
+++ b/RunGame/Services/GameStatsService.cs
@@ -1004,6 +1004,11 @@ namespace RunGame.Services
         Integer = 1,
 
         /// <summary>
+        /// Alias for Integer (some games use "Int" in their schema).
+        /// </summary>
+        Int = Integer,
+
+        /// <summary>
         /// Floating-point statistic.
         /// </summary>
         Float = 2,

--- a/count_cloc.bat
+++ b/count_cloc.bat
@@ -1,0 +1,18 @@
+@echo off
+:: 設定編碼為 UTF-8
+chcp 65001 >nul
+setlocal
+
+REM 使用絕對路徑指向工具
+set "CLOC_EXE=D:\tools\cloc-2.08.exe"
+set "TARGET_DIR=D:\Github\AchievoLab"
+
+echo [INFO] 正在統計 %TARGET_DIR% 的程式碼行數...
+
+REM 統計指令：使用正斜線 / 以避免反斜線 \ 的轉義問題
+"%CLOC_EXE%" "%TARGET_DIR%" ^
+    --fullpath ^
+    --not-match-d="(\.claude|\.git|\.vs|build|bin|obj|RunGame/obj|MyOwnGames/obj|AnSAM/obj|CommonUtilities/obj|MyOwnGames.Tests/obj|CommonUtilities.Tests/obj)" ^
+    --exclude-lang="JSON,XML"
+
+::pause


### PR DESCRIPTION
## Summary
- Add `Int = Integer` alias to `UserStatType` enum in `GameStatsService.cs`
- Some Steam games use `Int` instead of `Integer` in their stat schema, causing those stats to be silently ignored during parsing
- Ref: gibbed/SteamAchievementManager@de8b71048a0cee3c3e97cd8535e0f55ca86513e4

## Test plan
- [ ] Build the solution successfully
- [ ] Launch RunGame with a game known to use "Int" stat type and verify stats are loaded correctly
- [ ] Verify existing games with "Integer" stat type still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)