### PR TITLE
Fix Avalonia obsolete Watermark and null reference warnings

### DIFF
--- a/MyOwnGames/MainWindow.axaml
+++ b/MyOwnGames/MainWindow.axaml
@@ -16,7 +16,7 @@
             <!-- Search -->
             <AutoCompleteBox x:Name="KeywordBox"
                              Width="240"
-                             Watermark="Keyword search"
+                             PlaceholderText="Keyword search"
                              FilterMode="Contains" />
 
             <Separator Width="1" Margin="4,4"/>
@@ -26,7 +26,7 @@
             <TextBox x:Name="ApiKeyBox"
                      Width="240"
                      PasswordChar="*"
-                     Watermark="Your Steam Web API Key"
+                     PlaceholderText="Your Steam Web API Key"
                      RevealPassword="False" />
 
             <Separator Width="1" Margin="4,4"/>
@@ -36,7 +36,7 @@
             <TextBox x:Name="SteamIdBox"
                      Width="180"
                      PasswordChar="*"
-                     Watermark="7656119xxxxxxxxxx"
+                     PlaceholderText="7656119xxxxxxxxxx"
                      RevealPassword="False" />
 
             <Separator Width="1" Margin="4,4"/>

--- a/RunGame/MainWindow.axaml
+++ b/RunGame/MainWindow.axaml
@@ -32,7 +32,7 @@
                 <Grid RowDefinitions="Auto,*">
                     <!-- Achievement Filters -->
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="10" Margin="10">
-                        <TextBox x:Name="SearchTextBox" Watermark="Search achievements..." Width="200"/>
+                        <TextBox x:Name="SearchTextBox" PlaceholderText="Search achievements..." Width="200"/>
                         <ToggleButton x:Name="ShowLockedButton" Content="Show Locked Only" Click="OnShowLockedToggle"/>
                         <ToggleButton x:Name="ShowUnlockedButton" Content="Show Unlocked Only" Click="OnShowUnlockedToggle"/>
                         <ComboBox x:Name="LanguageComboBox" PlaceholderText="Language" Width="120" SelectionChanged="OnLanguageChanged"/>

--- a/RunGame/MainWindow.axaml.cs
+++ b/RunGame/MainWindow.axaml.cs
@@ -446,7 +446,7 @@ namespace RunGame
         private async void OnStore(object sender, RoutedEventArgs e)
         {
             // Get selected achievements
-            var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
+            var selectedAchievements = (AchievementListView.SelectedItems ?? (System.Collections.IList)Array.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => !a.IsProtected)
                 .ToList();
@@ -1066,12 +1066,12 @@ namespace RunGame
 
         private async void OnSetTimer(object sender, RoutedEventArgs e)
         {
-            var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
+            var selectedAchievements = (AchievementListView.SelectedItems ?? (System.Collections.IList)Array.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => !a.IsAchieved && !a.IsProtected)
                 .ToList();
 
-            var achievedSelected = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
+            var achievedSelected = (AchievementListView.SelectedItems ?? (System.Collections.IList)Array.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => a.IsAchieved)
                 .ToList();
@@ -1246,7 +1246,7 @@ namespace RunGame
                     return;
                 }
 
-                var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
+                var selectedAchievements = (AchievementListView.SelectedItems ?? (System.Collections.IList)Array.Empty<object>())
                     .OfType<AchievementInfo>()
                     .ToList();
 

--- a/RunGame/MainWindow.axaml.cs
+++ b/RunGame/MainWindow.axaml.cs
@@ -446,7 +446,7 @@ namespace RunGame
         private async void OnStore(object sender, RoutedEventArgs e)
         {
             // Get selected achievements
-            var selectedAchievements = AchievementListView.SelectedItems
+            var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => !a.IsProtected)
                 .ToList();
@@ -925,7 +925,7 @@ namespace RunGame
         {
             AppLogger.LogDebug("Select all unlocked button clicked");
 
-            AchievementListView.SelectedItems.Clear();
+            AchievementListView.SelectedItems?.Clear();
 
             var unlockedAchievements = _achievements
                 .Where(a => !a.IsProtected && a.IsAchieved)
@@ -933,7 +933,7 @@ namespace RunGame
 
             foreach (var achievement in unlockedAchievements)
             {
-                AchievementListView.SelectedItems.Add(achievement);
+                AchievementListView.SelectedItems?.Add(achievement);
             }
 
             AppLogger.LogDebug($"Selected {unlockedAchievements.Count} unlocked achievements");
@@ -943,7 +943,7 @@ namespace RunGame
         {
             AppLogger.LogDebug("Select all locked button clicked");
 
-            AchievementListView.SelectedItems.Clear();
+            AchievementListView.SelectedItems?.Clear();
 
             var lockedAchievements = _achievements
                 .Where(a => !a.IsProtected && !a.IsAchieved)
@@ -951,7 +951,7 @@ namespace RunGame
 
             foreach (var achievement in lockedAchievements)
             {
-                AchievementListView.SelectedItems.Add(achievement);
+                AchievementListView.SelectedItems?.Add(achievement);
             }
 
             AppLogger.LogDebug($"Selected {lockedAchievements.Count} locked achievements");
@@ -961,7 +961,7 @@ namespace RunGame
         {
             AppLogger.LogDebug("Select All button clicked");
 
-            AchievementListView.SelectedItems.Clear();
+            AchievementListView.SelectedItems?.Clear();
 
             var selectableAchievements = _achievements
                 .Where(a => !a.IsProtected)
@@ -969,7 +969,7 @@ namespace RunGame
 
             foreach (var achievement in selectableAchievements)
             {
-                AchievementListView.SelectedItems.Add(achievement);
+                AchievementListView.SelectedItems?.Add(achievement);
             }
 
             AppLogger.LogDebug($"Selected {selectableAchievements.Count} achievements");
@@ -1066,12 +1066,12 @@ namespace RunGame
 
         private async void OnSetTimer(object sender, RoutedEventArgs e)
         {
-            var selectedAchievements = AchievementListView.SelectedItems
+            var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => !a.IsAchieved && !a.IsProtected)
                 .ToList();
 
-            var achievedSelected = AchievementListView.SelectedItems
+            var achievedSelected = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
                 .OfType<AchievementInfo>()
                 .Where(a => a.IsAchieved)
                 .ToList();
@@ -1246,7 +1246,7 @@ namespace RunGame
                     return;
                 }
 
-                var selectedAchievements = AchievementListView.SelectedItems
+                var selectedAchievements = (AchievementListView.SelectedItems ?? Enumerable.Empty<object>())
                     .OfType<AchievementInfo>()
                     .ToList();
 


### PR DESCRIPTION
## Summary
- Replace deprecated `Watermark` property with `PlaceholderText` in MyOwnGames and RunGame AXAML files (AVLN5001)
- Add null-safety for `SelectedItems` access to fix CS8602/CS8604 nullable reference warnings

## Test plan
- [x] Build solution with `dotnet build` and verify no AVLN5001, CS8602, or CS8604 warnings
- [x] Verify placeholder text still displays correctly in search/input fields
- [ ] Test achievement selection (lock all, unlock all, invert, store, timer) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)