### PR TITLE
Add tag-triggered release CI (Native AOT build + zipped release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+# Push a tag like `v1.0.0` to build a release. This workflow runs the unit
+# tests, then publishes via publish.ps1 (Native AOT, win-x64) and attaches the
+# zipped output to a GitHub Release for that tag.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # required to create the Release and upload assets
+
+jobs:
+  build-and-release:
+    name: Test, Build & Publish (Native AOT)
+    runs-on: windows-latest   # AOT win-x64 needs the MSVC toolchain (preinstalled here)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run unit tests
+        shell: pwsh
+        run: |
+          # The test projects are xUnit v3 / Microsoft.Testing.Platform apps
+          # (OutputType=Exe). On the .NET 10 SDK, `dotnet test` no longer drives
+          # them reliably, so we build each one and run its test executable
+          # directly. A non-zero exit code from any project fails the job and
+          # blocks the release.
+          $projects = @(
+            'CommonUtilities.Tests',
+            'AnSAM.Tests',
+            'MyOwnGames.Tests',
+            'RunGame.Tests'
+          )
+          $failed = $false
+          foreach ($proj in $projects) {
+            Write-Host "::group::$proj"
+            dotnet build "$proj/$proj.csproj" -c Debug --nologo
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "*** Build failed: $proj ***" -ForegroundColor Red
+              $failed = $true
+              Write-Host "::endgroup::"
+              continue
+            }
+            $exe = Join-Path $proj "bin/Debug/net10.0/$proj.exe"
+            if (-not (Test-Path $exe)) {
+              Write-Host "*** Test executable not found: $exe ***" -ForegroundColor Red
+              $failed = $true
+              Write-Host "::endgroup::"
+              continue
+            }
+            & $exe
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "*** Tests failed: $proj (exit $LASTEXITCODE) ***" -ForegroundColor Red
+              $failed = $true
+            }
+            Write-Host "::endgroup::"
+          }
+          if ($failed) { exit 1 }
+
+      - name: Publish (Native AOT, win-x64)
+        shell: pwsh
+        run: ./publish.ps1
+
+      - name: Package release zip
+        shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}'
+          $zipName = "AchievoLab-$tag-win-x64.zip"
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          # One archive that preserves the AnSAM/ RunGame/ MyOwnGames/ layout, so
+          # AnSAM can still resolve ..\RunGame\RunGame.exe after extraction.
+          Compress-Archive -Path 'publish/*' -DestinationPath "dist/$zipName" -Force
+          Get-ChildItem dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.zip
+          generate_release_notes: true
+          # Tags with a hyphen (e.g. v1.0.0-beta) are marked as pre-release.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/publish.ps1
+++ b/publish.ps1
@@ -39,3 +39,8 @@ if (-not $failed) {
     Write-Host " All projects published successfully!"
     Write-Host "========================================"
 }
+
+# Propagate a proper exit code so CI (and callers) can detect failures.
+if ($failed) {
+    exit 1
+}


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release.yml`: pushing a `v*` tag builds and publishes a release.

- Runs the four xUnit v3 / Microsoft.Testing.Platform test projects by executing each test exe directly (`dotnet test` is unreliable for MTP on the .NET 10 SDK); a failing project blocks the release.
- Publishes all three executables via `publish.ps1` (Native AOT, win-x64).
- Packages `publish/` into a single `AchievoLab-<tag>-win-x64.zip`, preserving the `AnSAM/ RunGame/ MyOwnGames/` layout so AnSAM can resolve `..\RunGame\RunGame.exe`.
- Creates/updates the GitHub Release for the tag and uploads the zip.

Also makes `publish.ps1` exit 1 on failure so CI detects publish errors.

Verified end-to-end via tag `v20260606` (run succeeded in 5m25s, release + zip produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)